### PR TITLE
Fix FormModel::$translator must not be accessed before initialization.

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -15,9 +15,9 @@ use Yiisoft\Validator\Validator;
  */
 abstract class FormModel implements FormModelInterface
 {
-    protected ?TranslatorInterface $translator;
-    protected ?string $translationDomain;
-    protected ?string $translationLocale;
+    protected ?TranslatorInterface $translator = null;
+    protected ?string $translationDomain = null;
+    protected ?string $translationLocale = null;
 
     private array $attributes;
     private array $attributesLabels;
@@ -226,7 +226,10 @@ abstract class FormModel implements FormModelInterface
 
         if (!empty($rules)) {
             $results = (new Validator(
-                $rules, $this->translator, $this->translationDomain, $this->translationLocale
+                $rules,
+                $this->translator,
+                $this->translationDomain,
+                $this->translationLocale
             ))->validate($this);
 
             foreach ($results as $attribute => $result) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/form/issues/29
