### PR TITLE
Use getter/setter for attributes if available.

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -338,7 +338,7 @@ abstract class FormModel implements FormModelInterface
 
         $getter = 'get' . $this->inflector->camelize($attribute);
         if (is_callable([$this, $getter], true)) {
-            $method = new ReflectionMethod($class, 'get' . $this->inflector->camelize($attribute));
+            $method = new ReflectionMethod($class, $getter);
             if ($method->getNumberOfRequiredParameters() === 0) {
                 return $this->$getter();
             }

--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -336,8 +336,8 @@ abstract class FormModel implements FormModelInterface
             throw new InvalidArgumentException("Undefined property: \"$class::$attribute\".");
         }
 
-        $getter = 'get' . $this->inflector->camelize($attribute);
-        if (is_callable([$this, $getter], true)) {
+        $getter = 'get' . $this->getInflector()->camelize($attribute) . 'Attribute';
+        if (is_callable([$this, $getter])) {
             $method = new ReflectionMethod($class, $getter);
             if ($method->getNumberOfRequiredParameters() === 0) {
                 return $this->$getter();
@@ -356,13 +356,16 @@ abstract class FormModel implements FormModelInterface
 
     private function writeProperty(string $attribute, $value): void
     {
-        $setter = 'set' . $this->inflector->camelize($attribute);
+        $setter = 'set' . $this->getInflector()->camelize($attribute) . 'Attribute';
         if (is_callable([$this, $setter])) {
             $method = new ReflectionMethod(static::class, $setter);
             if ($method->getNumberOfRequiredParameters() === 1) {
                 $this->$setter($value);
+                return;
             }
-        } else if ($this->isPublicAttribute($attribute)) {
+        }
+
+        if ($this->isPublicAttribute($attribute)) {
             $this->$attribute = $value;
         } else {
             $setter = fn($class, $attribute, $value) => $class->$attribute = $value;

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -162,6 +162,44 @@ final class FormModelTest extends TestCase
         $this->assertEquals(true, $form->getRememberMe());
     }
 
+    public function testSetterAndGetterForAttributes(): void
+    {
+        $form = new LoginForm();
+
+        $data = [
+            'LoginForm' => [
+                'login' => 'admin',
+            ],
+        ];
+
+        $this->assertTrue($form->load($data));
+
+        $this->assertEquals('app-admin', $form->getLogin());
+
+        $form->login('user');
+
+        $this->assertEquals('app-user', $form->getAttributeValue('login'));
+    }
+
+    public function testSetterAndGetterIsIgnoredWhenIncorrectNumberOfParameters(): void
+    {
+        $form = new LoginForm();
+
+        $data = [
+            'LoginForm' => [
+                'password' => '1234',
+            ],
+        ];
+
+        $this->assertTrue($form->load($data));
+
+        $this->assertEquals('1234', $form->getPassword());
+
+        $form->password('123456');
+
+        $this->assertEquals('123456', $form->getAttributeValue('password'));
+    }
+
     public function testFailedLoadForm(): void
     {
         $form1 = new LoginForm();

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -49,7 +49,7 @@ final class FormModelTest extends TestCase
         $form = new LoginForm();
 
         $form->login('admin');
-        $this->assertEquals('admin', $form->getAttributeValue('login'));
+        $this->assertEquals('app-admin', $form->getAttributeValue('login'));
 
         $form->password('123456');
         $this->assertEquals('123456', $form->getAttributeValue('password'));
@@ -157,7 +157,7 @@ final class FormModelTest extends TestCase
 
         $this->assertTrue($form->load($data));
 
-        $this->assertEquals('admin', $form->getLogin());
+        $this->assertEquals('app-admin', $form->getLogin());
         $this->assertEquals('123456', $form->getPassword());
         $this->assertEquals(true, $form->getRememberMe());
     }
@@ -269,19 +269,19 @@ final class FormModelTest extends TestCase
     {
         $form = new LoginForm();
 
-        $form->login('');
+        $form->password('');
         $form->validate();
 
         $this->assertEquals(
             ['Value cannot be blank.'],
-            $form->error('login')
+            $form->error('password')
         );
 
-        $form->login('x');
+        $form->password('x');
         $form->validate();
         $this->assertEquals(
             ['Is too short.'],
-            $form->error('login')
+            $form->error('password')
         );
 
         $form->login(str_repeat('x', 60));

--- a/tests/Stub/LoginForm.php
+++ b/tests/Stub/LoginForm.php
@@ -27,9 +27,19 @@ class LoginForm extends FormModel
         return $this->login;
     }
 
+    public function getLoginAttribute(): ?string
+    {
+        return $this->login !== null ? 'app-' . $this->login : null;
+    }
+
     public function getPassword(): ?string
     {
         return $this->password;
+    }
+
+    public function getPasswordAttribute(bool $param): ?string
+    {
+        return 'wrong';
     }
 
     public function getRememberMe(): bool
@@ -42,9 +52,19 @@ class LoginForm extends FormModel
         $this->login = $value;
     }
 
+    public function setLoginAttribute(string $value): void
+    {
+        $this->login = 'app-' . $value;
+    }
+
     public function password(string $value): void
     {
         $this->password = $value;
+    }
+
+    public function setPasswordAttribute(): void
+    {
+        $this->password = 'wrong';
     }
 
     public function rememberMe(bool $value): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

Use getter/setter for reading and writing attributes if they are available. Use case: when you pre-processing/formatting beforehand.
Also replaced `get_class($this)` with `static::class` as it is faster with less op calls: https://belineperspectives.com/2017/03/13/get_classthis-vs-staticclass/

P.S. Will add/fix tests after initial review.