### PR TITLE
Support for nested attributes.

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -13,9 +13,12 @@ use Yiisoft\Validator\ValidatorFactoryInterface;
 
 use function array_key_exists;
 use function array_merge;
+use function explode;
 use function get_object_vars;
+use function is_subclass_of;
 use function reset;
 use function sprintf;
+use function strpos;
 
 /**
  * Form model represents an HTML form: its data, validation and presentation.
@@ -141,44 +144,45 @@ abstract class FormModel implements FormModelInterface
         return $attribute === null ? !empty($this->attributesErrors) : isset($this->attributesErrors[$attribute]);
     }
 
-    public function load(array $data): bool
+    public function load(array $data, $formName = null): bool
     {
-        $result = false;
+        $scope = $formName ?? $this->formName();
 
-        $scope = $this->formName();
+        $values = [];
 
         if ($scope === '' && !empty($data)) {
-            $this->setAttributes($data);
-            $result = true;
+            $values = $data;
         } elseif (isset($data[$scope])) {
-            $this->setAttributes($data[$scope]);
-            $result = true;
+            $values = $data[$scope];
         }
 
-        return $result;
+        foreach ($values as $name => $value) {
+            $this->setAttribute($name, $value);
+        }
+
+        return $values !== [];
     }
 
-    public function setAttributes(array $values): void
+    public function setAttribute(string $name, $value): void
     {
-        foreach ($values as $name => $value) {
-            if (isset($this->attributes[$name])) {
-                switch ($this->attributes[$name]) {
-                    case 'bool':
-                        $this->writeProperty($name, (bool) $value);
-                        break;
-                    case 'float':
-                        $this->writeProperty($name, (float) $value);
-                        break;
-                    case 'int':
-                        $this->writeProperty($name, (int) $value);
-                        break;
-                    case 'string':
-                        $this->writeProperty($name, (string) $value);
-                        break;
-                    default:
-                        $this->writeProperty($name, $value);
-                        break;
-                }
+        [$realName] = $this->getNestedAttribute($name);
+        if (isset($this->attributes[$realName])) {
+            switch ($this->attributes[$realName]) {
+                case 'bool':
+                    $this->writeProperty($name, (bool) $value);
+                    break;
+                case 'float':
+                    $this->writeProperty($name, (float) $value);
+                    break;
+                case 'int':
+                    $this->writeProperty($name, (int) $value);
+                    break;
+                case 'string':
+                    $this->writeProperty($name, (string) $value);
+                    break;
+                default:
+                    $this->writeProperty($name, $value);
+                    break;
             }
         }
     }
@@ -329,15 +333,20 @@ abstract class FormModel implements FormModelInterface
     private function readProperty(string $attribute)
     {
         $class = get_class($this);
+
+        [$attribute, $nested] = $this->getNestedAttribute($attribute);
+
         if (!property_exists($class, $attribute)) {
             throw new InvalidArgumentException("Undefined property: \"$class::$attribute\".");
         }
 
         if ($this->isPublicAttribute($attribute)) {
-            return $this->$attribute;
+            return $nested === null ? $this->$attribute : $this->$attribute->getAttributeValue($nested);
         }
 
-        $getter = fn ($class, $attribute) => $class->$attribute;
+        $getter = fn (FormModel $class, $attribute) => $nested === null
+            ? $class->$attribute
+            : $class->$attribute->getAttributeValue($nested);
         $getter = Closure::bind($getter, null, $this);
 
         return $getter($this, $attribute);
@@ -345,10 +354,17 @@ abstract class FormModel implements FormModelInterface
 
     private function writeProperty(string $attribute, $value): void
     {
+        [$attribute, $nested] = $this->getNestedAttribute($attribute);
         if ($this->isPublicAttribute($attribute)) {
-            $this->$attribute = $value;
+            if ($nested === null) {
+                $this->$attribute = $value;
+            } else {
+                $this->$attribute->setAttribute($attribute, $value);
+            }
         } else {
-            $setter = fn($class, $attribute, $value) => $class->$attribute = $value;
+            $setter = fn(FormModel $class, $attribute, $value) => $nested === null
+                ? $class->$attribute = $value
+                : $class->$attribute->setAttribute($nested, $value);
             $setter = Closure::bind($setter, null, $this);
 
             $setter($this, $attribute, $value);
@@ -358,5 +374,20 @@ abstract class FormModel implements FormModelInterface
     private function isPublicAttribute(string $attribute): bool
     {
         return array_key_exists($attribute, get_object_vars($this));
+    }
+
+    private function getNestedAttribute(string $attribute): array
+    {
+        if (strpos($attribute, '.') === false) {
+            return [$attribute, null];
+        }
+
+        [$attribute, $nested] = explode('.', $attribute, 2);
+
+        if (!is_subclass_of($this->attributes[$attribute], self::class)) {
+            throw new InvalidArgumentException('Nested attribute can only be of ' . self::class . ' type.');
+        }
+
+        return [$attribute, $nested];
     }
 }

--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -65,6 +65,11 @@ abstract class FormModel implements FormModelInterface
 
     public function attributeHint(string $attribute): string
     {
+        [$attribute, $nested] = $this->getNestedAttribute($attribute);
+        if ($nested !== null) {
+            return $this->readProperty($attribute)->attributeHint($nested);
+        }
+
         $hints = $this->attributeHints();
 
         return $hints[$attribute] ?? '';
@@ -77,7 +82,7 @@ abstract class FormModel implements FormModelInterface
 
     public function attributeLabel(string $attribute): string
     {
-        return $this->attributesLabels[$attribute] ?? $this->generateAttributeLabel($attribute);
+        return $this->attributesLabels[$attribute] ?? $this->getAttributeLabel($attribute);
     }
 
     /**
@@ -311,6 +316,15 @@ abstract class FormModel implements FormModelInterface
             $this->inflector = new Inflector();
         }
         return $this->inflector;
+    }
+
+    private function getAttributeLabel(string $attribute): string
+    {
+        [$attribute, $nested] = $this->getNestedAttribute($attribute);
+
+        return $nested !== null
+            ? $this->readProperty($attribute)->attributeLabel($nested)
+            : $this->generateAttributeLabel($attribute);
     }
 
     /**

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -198,14 +198,15 @@ interface FormModelInterface extends DataSetInterface
      * ```
      *
      * `load()` gets the `'FormName'` from the {@see formName()} method (which you may override), unless the
-     * `$formName` parameter is given. If the form name is empty, `load()` populates the model with the whole of
+     * `$formName` parameter is given. If the form name is empty string, `load()` populates the model with the whole of
      * `$data` instead of `$data['FormName']`.
      *
      * @param array $data the data array to load, typically server request attributes.
+     * @param string|null $formName scope from which to get data
      *
      * @return bool whether `load()` found the expected form in `$data`.
      */
-    public function load(array $data): bool;
+    public function load(array $data, $formName = null): bool;
 
     /**
      * Performs the data validation.
@@ -223,9 +224,10 @@ interface FormModelInterface extends DataSetInterface
     public function validate(): bool;
 
     /**
-     * Sets the attribute values in a massive way.
+     * Set specified attribute
      *
-     * @param array $values attribute values (name => value) to be assigned to the model.
+     * @param string $name of the attribute to set
+     * @param mixed $value value
      */
-    public function setAttributes(array $values): void;
+    public function setAttribute(string $name, $value): void;
 }

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Yiisoft\Form\FormModel;
 use Yiisoft\Form\Tests\Stub\LoginForm;
 
+use Yiisoft\Validator\Rule\Required;
 use Yiisoft\Validator\ValidatorFactoryInterface;
 
 use function str_repeat;
@@ -79,12 +80,26 @@ final class FormModelTest extends TestCase
         $this->assertEmpty($form->attributeHint('noExist'));
     }
 
+    public function testGetNestedAttributeHint(): void
+    {
+        $form = new FormWithNestedAttribute();
+
+        $this->assertEquals('Write your id or email.', $form->attributeHint('user.login'));
+    }
+
     public function testGetAttributeLabel(): void
     {
         $form = new LoginForm();
 
         $this->assertEquals('Login:', $form->attributeLabel('login'));
         $this->assertEquals('Testme', $form->attributeLabel('testme'));
+    }
+
+    public function testGetNestedAttributeLabel(): void
+    {
+        $form = new FormWithNestedAttribute();
+
+        $this->assertEquals('Login:', $form->attributeLabel('user.login'));
     }
 
     public function testAttributesLabels(): void
@@ -314,6 +329,27 @@ final class FormWithNestedAttribute extends FormModel
     {
         $this->user = new LoginForm();
         parent::__construct(new ValidatorFactoryMock());
+    }
+
+    public function attributeLabels(): array
+    {
+        return [
+            'id' => 'ID',
+        ];
+    }
+
+    public function attributeHints(): array
+    {
+        return [
+            'id' => 'Readonly ID',
+        ];
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'id' => new Required(),
+        ];
     }
 
     public function setUserLogin(string $login): void

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -62,6 +62,14 @@ final class FormModelTest extends TestCase
         $form->getAttributeValue('noExist');
     }
 
+    public function testGetAttributeValueWithNestedAttribute(): void
+    {
+        $form = new FormWithNestedAttribute();
+
+        $form->setUserLogin('admin');
+        $this->assertEquals('admin', $form->getAttributeValue('user.login'));
+    }
+
     public function testGetAttributeHint(): void
     {
         $form = new LoginForm();
@@ -162,6 +170,20 @@ final class FormModelTest extends TestCase
         $this->assertEquals(true, $form->getRememberMe());
     }
 
+    public function testLoadWithNestedAttribute(): void
+    {
+        $form = new FormWithNestedAttribute();
+
+        $data = [
+            'FormWithNestedAttribute' => [
+                'user.login' => 'admin',
+            ],
+        ];
+
+        $this->assertTrue($form->load($data));
+        $this->assertEquals('admin', $form->getUserLogin());
+    }
+
     public function testFailedLoadForm(): void
     {
         $form1 = new LoginForm();
@@ -185,7 +207,7 @@ final class FormModelTest extends TestCase
         $this->assertFalse($form2->load($data2));
     }
 
-    public function testSetAttributes()
+    public function testLoadWithEmptyScope()
     {
         $form = new class(new ValidatorFactoryMock()) extends FormModel{
             private int $int = 1;
@@ -193,12 +215,12 @@ final class FormModelTest extends TestCase
             private float $float = 3.14;
             private bool $bool = true;
         };
-        $form->setAttributes([
+        $form->load([
             'int' => '2',
             'float' => '3.15',
             'bool' => 'false',
             'string' => 555,
-        ]);
+        ], '');
         $this->assertIsInt($form->getAttributeValue('int'));
         $this->assertIsFloat($form->getAttributeValue('float'));
         $this->assertIsBool($form->getAttributeValue('bool'));
@@ -280,5 +302,27 @@ final class CustomFormNameForm extends FormModel
     public function formName(): string
     {
         return 'my-best-form-name';
+    }
+}
+
+final class FormWithNestedAttribute extends FormModel
+{
+    private ?int $id = null;
+    private ?LoginForm $user = null;
+
+    public function __construct()
+    {
+        $this->user = new LoginForm();
+        parent::__construct(new ValidatorFactoryMock());
+    }
+
+    public function setUserLogin(string $login): void
+    {
+        $this->user->login('admin');
+    }
+
+    public function getUserLogin(): ?string
+    {
+        return $this->user->getLogin();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | reference [#17](https://github.com/yiisoft/form/issues/17#issuecomment-671545891)

The only reason this PR also breaks BC is that I have removed public `setAttributes` method from `FormModelInterface` and `FormModel` as it didn't have any reason to be there. The same thing could have been done with `load`. Even documentation for `load` was saying the same thing, but wasn't supporting that behavior. I have also added new public method to the interface and class `setAttribute(string $name, $value)` which encapsulated some of the logic from `setAttributes` that was removed and this new method is used in my implementation of nested attributes.