### PR TITLE
Fix add success class to field.

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -32,7 +32,7 @@ abstract class FormModel implements FormModelInterface
     private array $attributesLabels;
     private array $attributesErrors = [];
     private ?Inflector $inflector = null;
-    private bool $isValidate = false;
+    private bool $validated = false;
 
     public function __construct(ValidatorFactoryInterface $validatorFactory)
     {
@@ -232,7 +232,7 @@ abstract class FormModel implements FormModelInterface
             }
         }
 
-        $this->isValidate = true;
+        $this->validated = true;
 
         return !$this->hasErrors();
     }
@@ -333,7 +333,7 @@ abstract class FormModel implements FormModelInterface
             unset($this->attributesErrors[$attribute]);
         }
 
-        $this->isValidate = false;
+        $this->validated = false;
     }
 
     private function getInflector(): Inflector
@@ -441,6 +441,6 @@ abstract class FormModel implements FormModelInterface
 
     public function isValidated(): bool
     {
-        return $this->isValidate;
+        return $this->validated;
     }
 }

--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -439,7 +439,7 @@ abstract class FormModel implements FormModelInterface
         return [$attribute, $nested];
     }
 
-    public function isValidate(): bool
+    public function isValidated(): bool
     {
         return $this->isValidate;
     }

--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -32,6 +32,7 @@ abstract class FormModel implements FormModelInterface
     private array $attributesLabels;
     private array $attributesErrors = [];
     private ?Inflector $inflector = null;
+    private bool $isValidate = false;
 
     public function __construct(ValidatorFactoryInterface $validatorFactory)
     {
@@ -231,6 +232,8 @@ abstract class FormModel implements FormModelInterface
             }
         }
 
+        $this->isValidate = true;
+
         return !$this->hasErrors();
     }
 
@@ -329,6 +332,8 @@ abstract class FormModel implements FormModelInterface
         } else {
             unset($this->attributesErrors[$attribute]);
         }
+
+        $this->isValidate = false;
     }
 
     private function getInflector(): Inflector
@@ -432,5 +437,10 @@ abstract class FormModel implements FormModelInterface
         }
 
         return [$attribute, $nested];
+    }
+
+    public function isValidate(): bool
+    {
+        return $this->isValidate;
     }
 }

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -234,7 +234,7 @@ interface FormModelInterface extends DataSetInterface
     /**
      * This method allows to know if the validation was executed or not in the model.
      *
-     * @return bool
+     * @return bool If the model was validated.
      */
     public function isValidated(): bool;
 }

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -230,4 +230,11 @@ interface FormModelInterface extends DataSetInterface
      * @param mixed $value value
      */
     public function setAttribute(string $name, $value): void;
+
+    /**
+     * This method allows to know if the validation was executed or not in the model.
+     *
+     * @return bool
+     */
+    public function isValidate(): bool;
 }

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -236,5 +236,5 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return bool
      */
-    public function isValidate(): bool;
+    public function isValidated(): bool;
 }

--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -936,7 +936,7 @@ final class Field extends Widget
         if ($this->validationStateOn === 'input') {
             $attributeName = HtmlForm::getAttributeName($this->attribute);
 
-            if (!$this->data->hasErrors($attributeName) && !empty($this->data->getAttributeValue($attributeName))) {
+            if (!$this->data->hasErrors($attributeName) && $this->data->isValidate()) {
                 /**
                  * @psalm-suppress PossiblyNullPropertyAssignmentValue
                  */

--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -936,7 +936,7 @@ final class Field extends Widget
         if ($this->validationStateOn === 'input') {
             $attributeName = HtmlForm::getAttributeName($this->attribute);
 
-            if (!$this->data->hasErrors($attributeName)) {
+            if (!$this->data->hasErrors($attributeName) && !empty($this->data->getAttributeValue($attributeName))) {
                 /**
                  * @psalm-suppress PossiblyNullPropertyAssignmentValue
                  */

--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -936,11 +936,7 @@ final class Field extends Widget
         if ($this->validationStateOn === 'input') {
             $attributeName = HtmlForm::getAttributeName($this->attribute);
 
-            if (
-                !$this->data->hasErrors($attributeName) &&
-                $this->data->isValidated() &&
-                !empty($this->data->getAttributeValue($attributeName))
-            ) {
+            if (!$this->data->hasErrors($attributeName) && $this->data->isValidated()) {
                 /**
                  * @psalm-suppress PossiblyNullPropertyAssignmentValue
                  */

--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -938,7 +938,7 @@ final class Field extends Widget
 
             if (
                 !$this->data->hasErrors($attributeName) &&
-                $this->data->isValidate() &&
+                $this->data->isValidated() &&
                 !empty($this->data->getAttributeValue($attributeName))
             ) {
                 /**

--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -936,7 +936,11 @@ final class Field extends Widget
         if ($this->validationStateOn === 'input') {
             $attributeName = HtmlForm::getAttributeName($this->attribute);
 
-            if (!$this->data->hasErrors($attributeName) && $this->data->isValidate()) {
+            if (
+                !$this->data->hasErrors($attributeName) &&
+                $this->data->isValidate() &&
+                !empty($this->data->getAttributeValue($attributeName))
+            ) {
                 /**
                  * @psalm-suppress PossiblyNullPropertyAssignmentValue
                  */

--- a/tests/Widget/FieldDropDownListTest.php
+++ b/tests/Widget/FieldDropDownListTest.php
@@ -31,7 +31,7 @@ final class FieldDropDownListTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-citybirth">
 <label class="control-label" for="personalform-citybirth">City Birth</label>
-<select id="personalform-citybirth" class="form-control has-success" name="PersonalForm[cityBirth]">
+<select id="personalform-citybirth" class="form-control" name="PersonalForm[cityBirth]">
 <option value="1">Moscu</option>
 <option value="2">San Petersburgo</option>
 <option value="3">Novosibirsk</option>
@@ -53,7 +53,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-citybirth">
 <label class="control-label customLabelClass" for="personalform-citybirth">City Birth:</label>
-<select id="personalform-citybirth" class="form-control has-success" name="PersonalForm[cityBirth]">
+<select id="personalform-citybirth" class="form-control" name="PersonalForm[cityBirth]">
 <option value="0" selected="selected">Select City Birth</option>
 <option value="1">Moscu</option>
 <option value="2">San Petersburgo</option>
@@ -99,7 +99,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-citybirth">
 <label class="control-label" for="personalform-citybirth">City Birth</label>
-<select id="personalform-citybirth" class="form-control has-success" name="PersonalForm[cityBirth]">
+<select id="personalform-citybirth" class="form-control" name="PersonalForm[cityBirth]">
 <option value="0" selected="selected">Select City Birth</option>
 <optgroup label="Chile">
 <option value="1">Santiago</option>
@@ -141,7 +141,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-citybirth">
 
-<input type="hidden" name="PersonalForm[cityBirth]" value="0"><select id="personalform-citybirth" class="form-control has-success" name="PersonalForm[cityBirth][]" multiple size="5">
+<input type="hidden" name="PersonalForm[cityBirth]" value="0"><select id="personalform-citybirth" class="form-control" name="PersonalForm[cityBirth][]" multiple size="5">
 <option value="0" selected="selected">Select City Birth</option>
 <option value="1">Moscu</option>
 <option value="2">San Petersburgo</option>

--- a/tests/Widget/FieldFileInputTest.php
+++ b/tests/Widget/FieldFileInputTest.php
@@ -20,7 +20,7 @@ final class FieldFileInputTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-attachfiles">
 <label class="control-label" for="personalform-attachfiles">Attach Files</label>
-<input type="hidden" name="PersonalForm[attachFiles]" value=""><input type="file" id="personalform-attachfiles" class="form-control has-success" name="PersonalForm[attachFiles]">
+<input type="hidden" name="PersonalForm[attachFiles]" value=""><input type="file" id="personalform-attachfiles" class="form-control" name="PersonalForm[attachFiles]">
 
 <div class="help-block"></div>
 </div>
@@ -39,7 +39,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-attachfiles">
 <label class="control-label customClass" for="personalform-attachfiles">Attach Files:</label>
-<input type="hidden" name="PersonalForm[attachFiles]" value=""><input type="file" id="personalform-attachfiles" class="form-control has-success" name="PersonalForm[attachFiles]">
+<input type="hidden" name="PersonalForm[attachFiles]" value=""><input type="file" id="personalform-attachfiles" class="form-control" name="PersonalForm[attachFiles]">
 
 <div class="help-block"></div>
 </div>
@@ -59,7 +59,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-attachfiles">
 
-<input type="hidden" name="PersonalForm[attachFiles]" value=""><input type="file" id="personalform-attachfiles" class="form-control has-success" name="PersonalForm[attachFiles]">
+<input type="hidden" name="PersonalForm[attachFiles]" value=""><input type="file" id="personalform-attachfiles" class="form-control" name="PersonalForm[attachFiles]">
 
 <div class="help-block"></div>
 </div>
@@ -79,7 +79,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-attachfiles">
 <label class="control-label" for="personalform-attachfiles">Attach Files</label>
-<input type="file" id="personalform-attachfiles" class="form-control has-success" name="PersonalForm[attachFiles]">
+<input type="file" id="personalform-attachfiles" class="form-control" name="PersonalForm[attachFiles]">
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldHintTest.php
+++ b/tests/Widget/FieldHintTest.php
@@ -17,7 +17,7 @@ final class FieldHintTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -35,7 +35,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
 <div class="hint-block customClass">Custom hint.</div>
 <div class="help-block"></div>
 </div>
@@ -54,7 +54,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldInputTest.php
+++ b/tests/Widget/FieldInputTest.php
@@ -37,7 +37,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-email">
 <label class="control-label customClass" for="personalform-email">Email:</label>
-<input type="email" id="personalform-email" class="form-control has-success" name="PersonalForm[email]" placeholder="Email">
+<input type="email" id="personalform-email" class="form-control" name="PersonalForm[email]" placeholder="Email">
 
 <div class="help-block"></div>
 </div>
@@ -57,7 +57,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-email">
 
-<input type="email" id="personalform-email" class="form-control has-success" name="PersonalForm[email]" placeholder="Email">
+<input type="email" id="personalform-email" class="form-control" name="PersonalForm[email]" placeholder="Email">
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldInputTest.php
+++ b/tests/Widget/FieldInputTest.php
@@ -18,7 +18,7 @@ final class FieldInputTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-email">
 <label class="control-label" for="personalform-email">Email</label>
-<input type="email" id="personalform-email" class="form-control has-success" name="PersonalForm[email]" value="admin@example.com" placeholder="Email">
+<input type="email" id="personalform-email" class="form-control" name="PersonalForm[email]" value="admin@example.com" placeholder="Email">
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldLabelTest.php
+++ b/tests/Widget/FieldLabelTest.php
@@ -17,7 +17,7 @@ final class FieldLabelTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-email">
 <label class="control-label" for="personalform-email">Email</label>
-<input type="text" id="personalform-email" class="form-control has-success" name="PersonalForm[email]" placeholder="Email">
+<input type="text" id="personalform-email" class="form-control" name="PersonalForm[email]" placeholder="Email">
 
 <div class="help-block"></div>
 </div>
@@ -35,7 +35,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-email">
 <label class="control-label labelTestMe" for="personalform-email">Email:</label>
-<input type="text" id="personalform-email" class="form-control has-success" name="PersonalForm[email]" placeholder="Email">
+<input type="text" id="personalform-email" class="form-control" name="PersonalForm[email]" placeholder="Email">
 
 <div class="help-block"></div>
 </div>
@@ -54,7 +54,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-email">
 
-<input type="text" id="personalform-email" class="form-control has-success" name="PersonalForm[email]" placeholder="Email">
+<input type="text" id="personalform-email" class="form-control" name="PersonalForm[email]" placeholder="Email">
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldPasswordInputTest.php
+++ b/tests/Widget/FieldPasswordInputTest.php
@@ -39,7 +39,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-password">
 <label class="control-label customClass required" for="personalform-password">Password:</label>
-<input type="password" id="personalform-password" class="form-control has-success" name="PersonalForm[password]" aria-required="true" placeholder="Password">
+<input type="password" id="personalform-password" class="form-control" name="PersonalForm[password]" aria-required="true" placeholder="Password">
 
 <div class="help-block"></div>
 </div>
@@ -59,7 +59,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-password">
 
-<input type="password" id="personalform-password" class="form-control has-success" name="PersonalForm[password]" aria-required="true" placeholder="Password">
+<input type="password" id="personalform-password" class="form-control" name="PersonalForm[password]" aria-required="true" placeholder="Password">
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldRadioListTest.php
+++ b/tests/Widget/FieldRadioListTest.php
@@ -18,7 +18,7 @@ final class FieldRadioListTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-sex">
 <label class="control-label" for="personalform-sex">Sex</label>
-<input type="hidden" name="PersonalForm[sex]" value=""><div id="personalform-sex" class="form-control has-success" role="radiogroup"><label><input type="radio" name="PersonalForm[sex]" value="1"> Female</label>
+<input type="hidden" name="PersonalForm[sex]" value=""><div id="personalform-sex" class="form-control" role="radiogroup"><label><input type="radio" name="PersonalForm[sex]" value="1"> Female</label>
 <label><input type="radio" name="PersonalForm[sex]" value="2"> Male</label></div>
 
 <div class="help-block"></div>
@@ -39,7 +39,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-sex">
 <label class="control-label customClass" for="personalform-sex">Sex:</label>
-<input type="hidden" name="PersonalForm[sex]" value=""><div id="personalform-sex" class="form-control has-success" role="radiogroup"><label><input type="radio" name="PersonalForm[sex]" value="1"> Female</label>
+<input type="hidden" name="PersonalForm[sex]" value=""><div id="personalform-sex" class="form-control" role="radiogroup"><label><input type="radio" name="PersonalForm[sex]" value="1"> Female</label>
 <label><input type="radio" name="PersonalForm[sex]" value="2"> Male</label></div>
 
 <div class="help-block"></div>
@@ -61,7 +61,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-sex">
 
-<input type="hidden" name="PersonalForm[sex]" value=""><div id="personalform-sex" class="form-control has-success" role="radiogroup"><label><input type="radio" name="PersonalForm[sex]" value="1"> Female</label>
+<input type="hidden" name="PersonalForm[sex]" value=""><div id="personalform-sex" class="form-control" role="radiogroup"><label><input type="radio" name="PersonalForm[sex]" value="1"> Female</label>
 <label><input type="radio" name="PersonalForm[sex]" value="2"> Male</label></div>
 
 <div class="help-block"></div>

--- a/tests/Widget/FieldTest.php
+++ b/tests/Widget/FieldTest.php
@@ -17,7 +17,7 @@ final class FieldTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -32,7 +32,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -66,7 +66,7 @@ HTML;
 
         $expected = <<<'HTML'
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 HTML;

--- a/tests/Widget/FieldTextAreaTest.php
+++ b/tests/Widget/FieldTextAreaTest.php
@@ -37,7 +37,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-address">
 <label class="control-label customClass" for="personalform-address">Address:</label>
-<textarea id="personalform-address" class="form-control has-success" name="PersonalForm[address]" placeholder="Address"></textarea>
+<textarea id="personalform-address" class="form-control" name="PersonalForm[address]" placeholder="Address"></textarea>
 
 <div class="help-block"></div>
 </div>
@@ -57,7 +57,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-address">
 
-<textarea id="personalform-address" class="form-control has-success" name="PersonalForm[address]" placeholder="Address"></textarea>
+<textarea id="personalform-address" class="form-control" name="PersonalForm[address]" placeholder="Address"></textarea>
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldTextAreaTest.php
+++ b/tests/Widget/FieldTextAreaTest.php
@@ -18,7 +18,7 @@ final class FieldTextAreaTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-address">
 <label class="control-label" for="personalform-address">Address</label>
-<textarea id="personalform-address" class="form-control has-success" name="PersonalForm[address]" placeholder="Address">San Petesburgo, Rusia</textarea>
+<textarea id="personalform-address" class="form-control" name="PersonalForm[address]" placeholder="Address">San Petesburgo, Rusia</textarea>
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldTextInputTest.php
+++ b/tests/Widget/FieldTextInputTest.php
@@ -17,7 +17,7 @@ final class FieldTextInputTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -35,7 +35,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label customClass required" for="personalform-name">Name:</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -54,7 +54,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FormTest.php
+++ b/tests/Widget/FormTest.php
@@ -100,7 +100,7 @@ final class FormTest extends TestCase
 
         $expected = <<<'HTML'
 <form action="/something" method="POST"><div class="form-group field-personalform-email">
-<input type="email" id="personalform-email" class="form-control has-success" name="PersonalForm[email]" value="admin@example.com" placeholder="Email">
+<input type="email" id="personalform-email" class="form-control" name="PersonalForm[email]" value="admin@example.com" placeholder="Email">
 </div></form>
 HTML;
         $this->assertEqualsWithoutLE($expected, $html);
@@ -115,7 +115,7 @@ HTML;
 
         $expected = <<<'HTML'
 <form class="formTestMe" action="/something" method="POST"><div class="form-group field-personalform-email fieldTestMe">
-<input type="email" id="personalform-email" class="form-control has-success" name="PersonalForm[email]" value="admin@example.com" required placeholder="Email">
+<input type="email" id="personalform-email" class="form-control" name="PersonalForm[email]" value="admin@example.com" required placeholder="Email">
 </div></form>
 HTML;
         $this->assertEqualsWithoutLE($expected, $html);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

- Just add the has-success class, if there are no errors and the validator was run.
