### PR TITLE
Fix: Adding required attribute

### DIFF
--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -972,6 +972,7 @@ final class Field extends Widget
     {
         if ($this->ariaAttribute) {
             if (!isset($options['aria-required']) && $this->data->isAttributeRequired($this->attribute)) {
+                $this->inputOptions['required'] = true;
                 $this->inputOptions['aria-required'] = 'true';
             }
 

--- a/tests/Widget/FieldErrorTest.php
+++ b/tests/Widget/FieldErrorTest.php
@@ -19,7 +19,7 @@ final class FieldErrorTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-error" name="PersonalForm[name]" value="yii" aria-required="true" aria-invalid="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control has-error" name="PersonalForm[name]" value="yii" required aria-required="true" aria-invalid="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block">Is too short.</div>
 </div>
@@ -40,7 +40,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-error" name="PersonalForm[name]" value="yii" aria-required="true" aria-invalid="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control has-error" name="PersonalForm[name]" value="yii" required aria-required="true" aria-invalid="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block errorTestMe">Is too short.</div>
 </div>

--- a/tests/Widget/FieldHintTest.php
+++ b/tests/Widget/FieldHintTest.php
@@ -17,7 +17,7 @@ final class FieldHintTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -35,7 +35,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" required aria-required="true" placeholder="Name">
 <div class="hint-block customClass">Custom hint.</div>
 <div class="help-block"></div>
 </div>
@@ -54,7 +54,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" required aria-required="true" placeholder="Name">
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldPasswordInputTest.php
+++ b/tests/Widget/FieldPasswordInputTest.php
@@ -20,7 +20,7 @@ final class FieldPasswordInputTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-password">
 <label class="control-label required" for="personalform-password">Password</label>
-<input type="password" id="personalform-password" class="form-control has-error" name="PersonalForm[password]" value="a7gh56ry" aria-required="true" aria-invalid="true" placeholder="Password">
+<input type="password" id="personalform-password" class="form-control has-error" name="PersonalForm[password]" value="a7gh56ry" required aria-required="true" aria-invalid="true" placeholder="Password">
 
 <div class="help-block">Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters.</div>
 </div>
@@ -39,7 +39,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-password">
 <label class="control-label customClass required" for="personalform-password">Password:</label>
-<input type="password" id="personalform-password" class="form-control" name="PersonalForm[password]" aria-required="true" placeholder="Password">
+<input type="password" id="personalform-password" class="form-control" name="PersonalForm[password]" required aria-required="true" placeholder="Password">
 
 <div class="help-block"></div>
 </div>
@@ -59,7 +59,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-password">
 
-<input type="password" id="personalform-password" class="form-control" name="PersonalForm[password]" aria-required="true" placeholder="Password">
+<input type="password" id="personalform-password" class="form-control" name="PersonalForm[password]" required aria-required="true" placeholder="Password">
 
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FieldSuccessTest.php
+++ b/tests/Widget/FieldSuccessTest.php
@@ -19,7 +19,7 @@ final class FieldSuccessTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" value="samdark" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" value="samdark" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -40,7 +40,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" value="samdark" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control has-success" name="PersonalForm[name]" value="samdark" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block errorTestMe"></div>
 </div>

--- a/tests/Widget/FieldTest.php
+++ b/tests/Widget/FieldTest.php
@@ -32,7 +32,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -48,7 +48,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-error" name="PersonalForm[name]" value="yii" aria-required="true" aria-invalid="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control has-error" name="PersonalForm[name]" value="yii" required aria-required="true" aria-invalid="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block">Is too short.</div>
 </div>
@@ -66,7 +66,7 @@ HTML;
 
         $expected = <<<'HTML'
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 HTML;

--- a/tests/Widget/FieldTextInputTest.php
+++ b/tests/Widget/FieldTextInputTest.php
@@ -17,7 +17,7 @@ final class FieldTextInputTest extends TestCase
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -35,7 +35,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label customClass required" for="personalform-name">Name:</label>
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>
@@ -54,7 +54,7 @@ HTML;
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div>

--- a/tests/Widget/FormTest.php
+++ b/tests/Widget/FormTest.php
@@ -137,7 +137,7 @@ HTML;
         $expected = <<<'HTML'
 <form action="/something" method="POST"><div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-testme has-success" name="PersonalForm[name]" value="yii test" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-testme has-success" name="PersonalForm[name]" value="yii test" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div></form>
@@ -153,7 +153,7 @@ HTML;
         $expected = <<<'HTML'
 <form action="/something" method="POST"><div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-testme has-success" name="PersonalForm[name]" value="yii test" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-testme has-success" name="PersonalForm[name]" value="yii test" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div></form>
@@ -237,7 +237,7 @@ HTML;
         $expected = <<<'HTML'
 <form action="/something" method="POST"><div class="form-group field-personalform-name has-error">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" value="yii" aria-required="true" aria-invalid="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control" name="PersonalForm[name]" value="yii" required aria-required="true" aria-invalid="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block">Is too short.</div>
 </div><div class="form-group field-personalform-email has-error">
@@ -267,7 +267,7 @@ HTML;
         $expected = <<<'HTML'
 <form action="/something" method="POST"><div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control has-error" name="PersonalForm[name]" value="yii" aria-required="true" aria-invalid="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control has-error" name="PersonalForm[name]" value="yii" required aria-required="true" aria-invalid="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block">Is too short.</div>
 </div><div class="form-group field-personalform-email">
@@ -347,7 +347,7 @@ HTML;
 <div class="help-block">This value is not a valid email address.</div>
 </div><div class="form-group field-personalform-name has-error">
 <label class="control-label required" for="personalform-name">Name</label>
-<input type="text" id="personalform-name" class="form-control testMe" name="PersonalForm[name]" value="Jack Ryan" aria-required="true" placeholder="Name">
+<input type="text" id="personalform-name" class="form-control testMe" name="PersonalForm[name]" value="Jack Ryan" required aria-required="true" placeholder="Name">
 <div class="hint-block">Write your first name.</div>
 <div class="help-block"></div>
 </div><div class="form-group field-personalform-citybirth has-error">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

`document.getElementById("form").reportValidity();` does not get triggered on `aria-required`. Adding `required` as well fixes this issue.