### PR TITLE
Start using external validation instead of internal

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Form;
 use Closure;
 use InvalidArgumentException;
 use ReflectionClass;
+use ReflectionNamedType;
 use Yiisoft\Form\HtmlOptions\HtmlOptionsProvider;
 use Yiisoft\Strings\Inflector;
 use Yiisoft\Strings\StringHelper;
@@ -272,6 +273,7 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
                 continue;
             }
 
+            /** @var ReflectionNamedType $type */
             $type = $property->getType();
             if ($type === null) {
                 throw new InvalidArgumentException(sprintf(

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\Form;
 
 use Yiisoft\Validator\DataSetInterface;
-use Yiisoft\Validator\ValidatorInterface;
 
 /**
  * FormModelInterface model represents an HTML form: its data, validation and presentation.
@@ -242,21 +241,6 @@ interface FormModelInterface extends DataSetInterface
      * @return array Validation rules.
      */
     public function rules(): array;
-
-    /**
-     * Performs the data validation.
-     *
-     * This method executes the validation rules applicable.
-     * The following criteria are used to determine whether a rule is currently applicable:
-     *
-     * - the rule must be associated with the attributes.
-     *
-     * Errors found during the validation can be retrieved via {@see errors()}, {@see firstErrors()} and
-     * {@see firstError()}.
-     *
-     * @return bool whether the validation is successful without any error.
-     */
-    public function validate(ValidatorInterface $validator): bool;
 
     /**
      * Set specified attribute

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -138,8 +138,10 @@ final class FormModelTest extends TestCase
             'password' => 'Is too short.',
         ];
 
+        $validator = $this->createValidatorMock();
+
         $this->assertTrue($form->load($data));
-        $this->assertFalse($form->validate($this->createValidatorMock()));
+        $this->assertFalse($validator->validate($form)->isValid());
 
         $this->assertEquals(
             $expected,
@@ -273,10 +275,11 @@ final class FormModelTest extends TestCase
 
     public function testValidatorRules(): void
     {
+        $validator = $this->createValidatorMock();
         $form = new LoginForm();
 
         $form->login('');
-        $form->validate($this->createValidatorMock());
+        $validator->validate($form);
 
         $this->assertEquals(
             ['Value cannot be blank.'],
@@ -284,21 +287,21 @@ final class FormModelTest extends TestCase
         );
 
         $form->login('x');
-        $form->validate($this->createValidatorMock());
+        $validator->validate($form);
         $this->assertEquals(
             ['Is too short.'],
             $form->error('login')
         );
 
         $form->login(str_repeat('x', 60));
-        $form->validate($this->createValidatorMock());
+        $validator->validate($form);
         $this->assertEquals(
             'Is too long.',
             $form->firstError('login')
         );
 
         $form->login('admin@.com');
-        $form->validate($this->createValidatorMock());
+        $validator->validate($form);
         $this->assertEquals(
             'This value is not a valid email address.',
             $form->firstError('login')

--- a/tests/Stub/ValidatorMock.php
+++ b/tests/Stub/ValidatorMock.php
@@ -19,7 +19,7 @@ final class ValidatorMock implements ValidatorInterface
         $this->validator = new Validator(new Formatter());
     }
 
-    public function validate(DataSetInterface $dataSet, iterable $rules): ResultSet
+    public function validate(DataSetInterface $dataSet, iterable $rules = []): ResultSet
     {
         return $this->validator->validate($dataSet, $rules);
     }

--- a/tests/Widget/ErrorSummaryTest.php
+++ b/tests/Widget/ErrorSummaryTest.php
@@ -60,10 +60,12 @@ final class ErrorSummaryTest extends TestCase
             ],
         ];
 
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
-
         $data->load($record);
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
+
         $html = ErrorSummary::widget()->config($data, $options)->run();
         $this->assertEqualsWithoutLE($expected, $html);
     }

--- a/tests/Widget/ErrorTest.php
+++ b/tests/Widget/ErrorTest.php
@@ -30,8 +30,10 @@ final class ErrorTest extends TestCase
 
     public function testError(): void
     {
+        $validator = $this->createValidatorMock();
         $this->data->load($this->record);
-        $this->data->validate($this->createValidatorMock());
+
+        $validator->validate($this->data);
 
         $expected = '<div>Value cannot be blank.</div>';
         $html = Error::widget()
@@ -42,8 +44,10 @@ final class ErrorTest extends TestCase
 
     public function testErrorOptions(): void
     {
+        $validator = $this->createValidatorMock();
         $this->data->load($this->record);
-        $this->data->validate($this->createValidatorMock());
+
+        $validator->validate($this->data);
 
         $expected = '<div class="customClass">Value cannot be blank.</div>';
         $html = Error::widget()
@@ -54,8 +58,10 @@ final class ErrorTest extends TestCase
 
     public function testErrorErrorSource(): void
     {
+        $validator = $this->createValidatorMock();
         $this->data->load($this->record);
-        $this->data->validate($this->createValidatorMock());
+
+        $validator->validate($this->data);
 
         $expected = '<div>This is custom error message.</div>';
         $html = Error::widget()
@@ -67,8 +73,10 @@ final class ErrorTest extends TestCase
 
     public function testErrorNoEncode(): void
     {
+        $validator = $this->createValidatorMock();
         $this->data->load($this->record);
-        $this->data->validate($this->createValidatorMock());
+
+        $validator->validate($this->data);
 
         $expected = '<div>(&#10006;) This is custom error message.</div>';
         $html = Error::widget()
@@ -81,8 +89,10 @@ final class ErrorTest extends TestCase
 
     public function testErrorTag(): void
     {
+        $validator = $this->createValidatorMock();
         $this->data->load($this->record);
-        $this->data->validate($this->createValidatorMock());
+
+        $validator->validate($this->data);
 
         $expected = 'Value cannot be blank.';
         $html = Error::widget()

--- a/tests/Widget/FieldErrorTest.php
+++ b/tests/Widget/FieldErrorTest.php
@@ -14,9 +14,11 @@ final class FieldErrorTest extends TestCase
 {
     public function testFieldError(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->name('yii');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
@@ -35,9 +37,11 @@ HTML;
 
     public function testFieldErrorOptions(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->name('yii');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
@@ -57,9 +61,11 @@ HTML;
 
     public function testFieldsTabularInputErrors(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->name('yii');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $expected = <<<'HTML'
 <div class="form-group field-personalform-0-name">

--- a/tests/Widget/FieldPasswordInputTest.php
+++ b/tests/Widget/FieldPasswordInputTest.php
@@ -14,10 +14,11 @@ final class FieldPasswordInputTest extends TestCase
 {
     public function testFieldsPasswordInput(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
-
         $data->password('a7gh56ry');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $expected = <<<'HTML'
 <div class="form-group field-personalform-password">

--- a/tests/Widget/FieldSuccessTest.php
+++ b/tests/Widget/FieldSuccessTest.php
@@ -14,9 +14,11 @@ final class FieldSuccessTest extends TestCase
 {
     public function testFieldSuccess(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->name('samdark');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
@@ -35,9 +37,11 @@ HTML;
 
     public function testFieldErrorOptions(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->name('samdark');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
@@ -57,9 +61,11 @@ HTML;
 
     public function testFieldsTabularInputErrors(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->name('yii');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $expected = <<<'HTML'
 <div class="form-group field-personalform-0-name">

--- a/tests/Widget/FieldTest.php
+++ b/tests/Widget/FieldTest.php
@@ -45,8 +45,11 @@ HTML;
             ->run();
         $this->assertEqualsWithoutLE($expected, $html);
 
+        $validator = $this->createValidatorMock();
         $data->name('yii');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
+
         $expected = <<<'HTML'
 <div class="form-group field-personalform-name">
 <label class="control-label required" for="personalform-name">Name</label>

--- a/tests/Widget/FormTest.php
+++ b/tests/Widget/FormTest.php
@@ -125,10 +125,11 @@ HTML;
 
     public function testFormsFieldsOptions(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
-
         $data->name('yii test');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $html = Form::widget()->action('/something')->begin();
         $html .= Field::widget()
@@ -224,10 +225,12 @@ HTML;
             'validationStateOn()' => ['container'],
         ];
 
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->name('yii');
         $data->email('admin@example.com');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $html = Form::widget()->action('/something')->begin();
         $html .= Field::widget($fieldConfig)
@@ -254,10 +257,12 @@ HTML;
 
     public function testFormsFieldsValidationOnInput(): void
     {
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->name('yii');
         $data->email('admin');
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $html = Form::widget()->action('/something')->begin();
         $html .= Field::widget()
@@ -308,9 +313,11 @@ HTML;
             ],
         ];
 
+        $validator = $this->createValidatorMock();
         $data = new PersonalForm();
         $data->load($record);
-        $data->validate($this->createValidatorMock());
+
+        $validator->validate($data);
 
         $html = Form::widget()->action('/something')->begin();
         $html .= Field::widget($fieldConfig)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Depends on  | https://github.com/yiisoft/validator/pull/115

After this PR we can validate forms like the following: `$validator->validate($form)`.
Remind that now we need to pass the validator to the form over form's method `validate($validator)`.