### PR TITLE
Rename getters: add get prefix

### DIFF
--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -25,7 +25,7 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return array attribute labels (name => label)
      */
-    public function attributeLabels(): array;
+    public function getAttributeLabels(): array;
 
     /**
      * Returns the text label for the specified attribute.
@@ -34,9 +34,9 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return string the attribute label.
      *
-     * {@see attributeLabels()}
+     * {@see getAttributeLabels()}
      */
-    public function attributeLabel(string $attribute): string;
+    public function getAttributeLabel(string $attribute): string;
 
     /**
      * Returns the attribute hints.
@@ -52,7 +52,7 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return array attribute hints (name => hint)
      */
-    public function attributeHints(): array;
+    public function getAttributeHints(): array;
 
     /**
      * Returns the text hint for the specified attribute.
@@ -61,9 +61,9 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return string the attribute hint.
      *
-     * {@see attributeHints()}
+     * {@see getAttributeHints()}
      */
-    public function attributeHint(string $attribute): string;
+    public function getAttributeHint(string $attribute): string;
 
     /**
      * Returns a value indicating whether the attribute is required.
@@ -104,10 +104,10 @@ interface FormModelInterface extends DataSetInterface
      * ]
      * ```
      *
-     * {@see firstErrors()}
-     * {@see firstError()}
+     * {@see getFirstErrors()}
+     * {@see getFirstError()}
      */
-    public function errors(): array;
+    public function getErrors(): array;
 
     /**
      * Returns the errors for single attribute.
@@ -116,7 +116,7 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return array
      */
-    public function error(string $attribute): array;
+    public function getError(string $attribute): array;
 
     /**
      * Returns the errors for all attributes as a one-dimensional array.
@@ -126,10 +126,10 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return array errors for all attributes as a one-dimensional array. Empty array is returned if no error.
      *
-     * {@see errors()}
-     * {@see firstErrors(){}
+     * {@see getErrors()}
+     * {@see getFirstErrors(){}
      */
-    public function errorSummary(bool $showAllErrors): array;
+    public function getErrorSummary(bool $showAllErrors): array;
 
     /**
      * Returns a value indicating whether there is any validation error.
@@ -146,10 +146,10 @@ interface FormModelInterface extends DataSetInterface
      * @return array the first errors. The array keys are the attribute names, and the array values are the
      * corresponding error messages. An empty array will be returned if there is no error.
      *
-     * {@see errors()}
-     * {@see firstError()}
+     * {@see getErrors()}
+     * {@see getFirstError()}
      */
-    public function firstErrors(): array;
+    public function getFirstErrors(): array;
 
     /**
      * Returns the first error of the specified attribute.
@@ -158,10 +158,10 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return string the error message. Empty string is returned if there is no error.
      *
-     * {@see errors()}
-     * {@see firstErrors()}
+     * {@see getErrors()}
+     * {@see getFirstErrors()}
      */
-    public function firstError(string $attribute): string;
+    public function getFirstError(string $attribute): string;
 
     /**
      * Returns the form name that this model class should use.
@@ -181,7 +181,7 @@ interface FormModelInterface extends DataSetInterface
      *
      * {@see load()}
      */
-    public function formName(): string;
+    public function getFormName(): string;
 
     /**
      * Populates the model with input data.
@@ -197,7 +197,7 @@ interface FormModelInterface extends DataSetInterface
      * }
      * ```
      *
-     * `load()` gets the `'FormName'` from the {@see formName()} method (which you may override), unless the
+     * `load()` gets the `'FormName'` from the {@see getFormName()} method (which you may override), unless the
      * `$formName` parameter is given. If the form name is empty string, `load()` populates the model with the whole of
      * `$data` instead of `$data['FormName']`.
      *
@@ -240,7 +240,7 @@ interface FormModelInterface extends DataSetInterface
      *
      * @return array Validation rules.
      */
-    public function rules(): array;
+    public function getRules(): array;
 
     /**
      * Set specified attribute

--- a/src/Helper/HtmlForm.php
+++ b/src/Helper/HtmlForm.php
@@ -78,7 +78,7 @@ final class HtmlForm
      */
     public static function getInputName(FormModelInterface $form, string $attribute): string
     {
-        $formName = $form->formName();
+        $formName = $form->getFormName();
 
         $data = self::parseAttribute($attribute);
 

--- a/src/Widget/BooleanInput.php
+++ b/src/Widget/BooleanInput.php
@@ -35,7 +35,7 @@ final class BooleanInput extends Widget
         $type = $new->type;
 
         if ($new->enclosedByLabel) {
-            $new->options['label'] ??= $new->data->attributeLabel(HtmlForm::getAttributeName($new->attribute));
+            $new->options['label'] ??= $new->data->getAttributeLabel(HtmlForm::getAttributeName($new->attribute));
         }
 
         if ($new->uncheck) {

--- a/src/Widget/Error.php
+++ b/src/Widget/Error.php
@@ -30,7 +30,7 @@ final class Error extends Widget
         if ($errorSource !== null) {
             $error = $errorSource($new->data, $new->attribute);
         } else {
-            $error = $new->data->firstError(HtmlForm::getAttributeName($new->attribute));
+            $error = $new->data->getFirstError(HtmlForm::getAttributeName($new->attribute));
         }
 
         $tag = ArrayHelper::remove($new->options, 'tag', 'div');

--- a/src/Widget/ErrorSummary.php
+++ b/src/Widget/ErrorSummary.php
@@ -8,7 +8,6 @@ use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Form\FormModelInterface;
 use Yiisoft\Html\Html;
 use Yiisoft\Widget\Widget;
-
 use function array_merge;
 use function array_unique;
 use function array_values;
@@ -84,7 +83,7 @@ final class ErrorSummary extends Widget
         $lines = [];
 
         foreach ([$new->data] as $form) {
-            $lines = array_unique(array_merge($lines, $form->errorSummary($showAllErrors)));
+            $lines = array_unique(array_merge($lines, $form->getErrorSummary($showAllErrors)));
         }
 
         /**

--- a/src/Widget/Hint.php
+++ b/src/Widget/Hint.php
@@ -24,7 +24,7 @@ final class Hint extends Widget
     {
         $new = clone $this;
 
-        $hint = ArrayHelper::remove($new->options, 'hint', $new->data->attributeHint($new->attribute));
+        $hint = ArrayHelper::remove($new->options, 'hint', $new->data->getAttributeHint($new->attribute));
 
         if (empty($hint)) {
             return '';

--- a/src/Widget/Input.php
+++ b/src/Widget/Input.php
@@ -57,7 +57,7 @@ final class Input extends Widget
         $new = clone $this;
         $new->data = $data;
         $new->attribute = $attribute;
-        $rules = $data->rules()[$attribute] ?? [];
+        $rules = $data->getRules()[$attribute] ?? [];
         foreach ($rules as $rule) {
             if ($rule instanceof HtmlOptionsProvider) {
                 $new->options = array_merge($new->options, $rule->getHtmlOptions());
@@ -249,7 +249,7 @@ final class Input extends Widget
     {
         if (!isset($this->options['placeholder']) && !(in_array($this->type, ['date', 'file', 'hidden', 'color'], true))) {
             $attributeName = HtmlForm::getAttributeName($this->attribute);
-            $this->options['placeholder'] = $this->data->attributeLabel($attributeName);
+            $this->options['placeholder'] = $this->data->getAttributeLabel($attributeName);
         }
     }
 }

--- a/src/Widget/Label.php
+++ b/src/Widget/Label.php
@@ -35,7 +35,7 @@ final class Label extends Widget
         $label = ArrayHelper::remove(
             $new->options,
             'label',
-            $new->data->attributeLabel(HtmlForm::getAttributeName($new->attribute))
+            $new->data->getAttributeLabel(HtmlForm::getAttributeName($new->attribute))
         );
 
         return Html::label($label, $for, $new->options);

--- a/src/Widget/TextArea.php
+++ b/src/Widget/TextArea.php
@@ -302,7 +302,7 @@ final class TextArea extends Widget
     {
         if (!isset($this->options['placeholder'])) {
             $attributeName = HtmlForm::getAttributeName($this->attribute);
-            $this->options['placeholder'] = $this->data->attributeLabel($attributeName);
+            $this->options['placeholder'] = $this->data->getAttributeLabel($attributeName);
         }
     }
 }

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -19,25 +19,25 @@ final class FormModelTest extends TestCase
     public function testAnonymousFormName(): void
     {
         $form = new class() extends FormModel {};
-        $this->assertEquals('', $form->formName());
+        $this->assertEquals('', $form->getFormName());
     }
 
     public function testDefaultFormName(): void
     {
         $form = new DefaultFormNameForm();
-        $this->assertEquals('DefaultFormNameForm', $form->formName());
+        $this->assertEquals('DefaultFormNameForm', $form->getFormName());
     }
 
     public function testNonNamespacedFormName(): void
     {
         $form = new \NonNamespacedForm();
-        $this->assertEquals('NonNamespacedForm', $form->formName());
+        $this->assertEquals('NonNamespacedForm', $form->getFormName());
     }
 
     public function testCustomFormName(): void
     {
         $form = new CustomFormNameForm();
-        $this->assertEquals('my-best-form-name', $form->formName());
+        $this->assertEquals('my-best-form-name', $form->getFormName());
     }
 
     public function testUnknownPropertyType(): void
@@ -82,31 +82,31 @@ final class FormModelTest extends TestCase
     {
         $form = new LoginForm();
 
-        $this->assertEquals('Write your id or email.', $form->attributeHint('login'));
-        $this->assertEquals('Write your password.', $form->attributeHint('password'));
-        $this->assertEmpty($form->attributeHint('noExist'));
+        $this->assertEquals('Write your id or email.', $form->getAttributeHint('login'));
+        $this->assertEquals('Write your password.', $form->getAttributeHint('password'));
+        $this->assertEmpty($form->getAttributeHint('noExist'));
     }
 
     public function testGetNestedAttributeHint(): void
     {
         $form = new FormWithNestedAttribute();
 
-        $this->assertEquals('Write your id or email.', $form->attributeHint('user.login'));
+        $this->assertEquals('Write your id or email.', $form->getAttributeHint('user.login'));
     }
 
     public function testGetAttributeLabel(): void
     {
         $form = new LoginForm();
 
-        $this->assertEquals('Login:', $form->attributeLabel('login'));
-        $this->assertEquals('Testme', $form->attributeLabel('testme'));
+        $this->assertEquals('Login:', $form->getAttributeLabel('login'));
+        $this->assertEquals('Testme', $form->getAttributeLabel('testme'));
     }
 
     public function testGetNestedAttributeLabel(): void
     {
         $form = new FormWithNestedAttribute();
 
-        $this->assertEquals('Login:', $form->attributeLabel('user.login'));
+        $this->assertEquals('Login:', $form->getAttributeLabel('user.login'));
     }
 
     public function testAttributesLabels(): void
@@ -119,7 +119,7 @@ final class FormModelTest extends TestCase
             'rememberMe' => 'remember Me:',
         ];
 
-        $this->assertEquals($expected, $form->attributeLabels());
+        $this->assertEquals($expected, $form->getAttributeLabels());
     }
 
     public function testErrorSummary(): void
@@ -145,7 +145,7 @@ final class FormModelTest extends TestCase
 
         $this->assertEquals(
             $expected,
-            $form->errorSummary(false)
+            $form->getErrorSummary(false)
         );
 
         $expected = [
@@ -155,7 +155,7 @@ final class FormModelTest extends TestCase
 
         $this->assertEquals(
             $expected,
-            $form->errorSummary(true)
+            $form->getErrorSummary(true)
         );
     }
 
@@ -259,7 +259,7 @@ final class FormModelTest extends TestCase
         $form->addError('password', $errorMessage);
 
         $this->assertTrue($form->hasErrors());
-        $this->assertEquals($errorMessage, $form->firstError('password'));
+        $this->assertEquals($errorMessage, $form->getFirstError('password'));
     }
 
     public function testAddAndGetErrorForNonExistingAttribute(): void
@@ -270,7 +270,7 @@ final class FormModelTest extends TestCase
         $form->addError('form', $errorMessage);
 
         $this->assertTrue($form->hasErrors());
-        $this->assertEquals($errorMessage, $form->firstError('form'));
+        $this->assertEquals($errorMessage, $form->getFirstError('form'));
     }
 
     public function testValidatorRules(): void
@@ -283,28 +283,28 @@ final class FormModelTest extends TestCase
 
         $this->assertEquals(
             ['Value cannot be blank.'],
-            $form->error('login')
+            $form->getError('login')
         );
 
         $form->login('x');
         $validator->validate($form);
         $this->assertEquals(
             ['Is too short.'],
-            $form->error('login')
+            $form->getError('login')
         );
 
         $form->login(str_repeat('x', 60));
         $validator->validate($form);
         $this->assertEquals(
             'Is too long.',
-            $form->firstError('login')
+            $form->getFirstError('login')
         );
 
         $form->login('admin@.com');
         $validator->validate($form);
         $this->assertEquals(
             'This value is not a valid email address.',
-            $form->firstError('login')
+            $form->getFirstError('login')
         );
     }
 
@@ -320,7 +320,7 @@ final class DefaultFormNameForm extends FormModel
 
 final class CustomFormNameForm extends FormModel
 {
-    public function formName(): string
+    public function getFormName(): string
     {
         return 'my-best-form-name';
     }
@@ -337,21 +337,21 @@ final class FormWithNestedAttribute extends FormModel
         parent::__construct();
     }
 
-    public function attributeLabels(): array
+    public function getAttributeLabels(): array
     {
         return [
             'id' => 'ID',
         ];
     }
 
-    public function attributeHints(): array
+    public function getAttributeHints(): array
     {
         return [
             'id' => 'Readonly ID',
         ];
     }
 
-    public function rules(): array
+    public function getRules(): array
     {
         return [
             'id' => new Required(),

--- a/tests/Stub/HtmlOptionsForm.php
+++ b/tests/Stub/HtmlOptionsForm.php
@@ -25,7 +25,7 @@ final class HtmlOptionsForm extends FormModel
     private string $email = '';
     private string $combined = '';
 
-    public function rules(): array
+    public function getRules(): array
     {
         return [
             'number' => [

--- a/tests/Stub/LoginForm.php
+++ b/tests/Stub/LoginForm.php
@@ -46,7 +46,7 @@ class LoginForm extends FormModel
         $this->rememberMe = $value;
     }
 
-    public function attributeHints(): array
+    public function getAttributeHints(): array
     {
         return [
             'login' => 'Write your id or email.',
@@ -54,7 +54,7 @@ class LoginForm extends FormModel
         ];
     }
 
-    public function attributeLabels(): array
+    public function getAttributeLabels(): array
     {
         return [
             'login' => 'Login:',
@@ -63,7 +63,7 @@ class LoginForm extends FormModel
         ];
     }
 
-    public function rules(): array
+    public function getRules(): array
     {
         return [
             'login' => $this->loginRules(),

--- a/tests/Stub/PersonalForm.php
+++ b/tests/Stub/PersonalForm.php
@@ -27,12 +27,12 @@ final class PersonalForm extends FormModel
     private bool $terms = false;
     private ?string $attachFiles = null;
 
-    public function attributeLabels(): array
+    public function getAttributeLabels(): array
     {
         return [];
     }
 
-    public function attributeHints(): array
+    public function getAttributeHints(): array
     {
         return [
             'name' => 'Write your first name.',
@@ -49,7 +49,7 @@ final class PersonalForm extends FormModel
         return '(&#10006;) This is custom error message.';
     }
 
-    public function rules(): array
+    public function getRules(): array
     {
         return [
             'name' => [new Required(), (new HasLength())->min(4)->tooShortMessage('Is too short.')],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | 

We have decided to name getters with `get` prefix. I think forms getters should follow this rule too.