### PR TITLE
[Bug Fix #97] Radio List widget value type casting fix

### DIFF
--- a/src/Widget/RadioList.php
+++ b/src/Widget/RadioList.php
@@ -211,6 +211,11 @@ final class RadioList extends Widget
             throw new InvalidArgumentException('RadioList widget required bool|float|int|string|null.');
         }
 
+        $_value = (int) $value;
+        if (is_string($value) && $value !== '0' && $_value === 0) {
+            $_value = $value;
+        }
+
         if ($new->separator !== '') {
             $radioList = $radioList->separator($new->separator);
         }
@@ -224,7 +229,7 @@ final class RadioList extends Widget
             ->radioAttributes($new->attributes)
             ->replaceRadioAttributes($new->itemsAttributes)
             ->uncheckValue($forceUncheckedValue)
-            ->value((int) $value)
+            ->value($_value)
             ->render();
     }
 }

--- a/tests/Widget/FieldRadioListTest.php
+++ b/tests/Widget/FieldRadioListTest.php
@@ -18,6 +18,7 @@ final class FieldRadioListTest extends TestCase
     use TestTrait;
 
     private array $sex = [1 => 'Female', 2 => 'Male'];
+    private array $mobileOs = ['android' => 'Android', 'ios' => 'iOS', 'pureos' => 'PureOS'];
     private TypeForm $formModel;
 
     public function testContainerAttributes(): void
@@ -336,6 +337,24 @@ final class FieldRadioListTest extends TestCase
         $this->assertEqualsWithoutLE(
             $expected,
             Field::widget()->config($this->formModel, 'string')->radioList([], $this->sex)->render(),
+        );
+
+        // value string 'ios'
+        $this->formModel->setAttribute('string', 'ios');
+        $expected = <<<'HTML'
+        <div>
+        <label for="typeform-string">String</label>
+        <div id="typeform-string">
+        <label><input type="radio" name="TypeForm[string]" value="android"> Android</label>
+        <label><input type="radio" name="TypeForm[string]" value="ios" checked> iOS</label>
+        <label><input type="radio" name="TypeForm[string]" value="pureos"> PureOS</label>
+        </div>
+        <div>Write your text string.</div>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()->config($this->formModel, 'string')->radioList([], $this->mobileOs)->render(),
         );
 
         // value null


### PR DESCRIPTION
Now string type values will be checked for radio list.