### PR TITLE
Separate templates for each widget

### DIFF
--- a/src/Widget/Attribute/FieldAttributes.php
+++ b/src/Widget/Attribute/FieldAttributes.php
@@ -31,6 +31,7 @@ trait FieldAttributes
     private string $validClass = '';
     private array $parts = [];
     private string $template = "{label}\n{input}\n{hint}\n{error}";
+    private array $widgetTemplates = [];
     private string $validationStateOn = 'input';
     private ?FormModelInterface $formModel = null;
 
@@ -151,6 +152,48 @@ trait FieldAttributes
     {
         $new = clone $this;
         $new->template = $value;
+        return $new;
+    }
+
+    /**
+     * Set layout templates for each widget
+     *
+     * @param array $templates
+     * @param bool $replace
+     *
+     * @return static
+     */
+    public function widgetTemplates(array $templates, bool $replace = false): self
+    {
+        $new = clone $this;
+
+        if ($replace) {
+            $new->widgetTemplates = $templates;
+        } else {
+            $new->widgetTemplates = array_merge($new->widgetTemplates, $templates);
+        }
+
+        return $new;
+    }
+
+    /**
+     * Set layout template for current widget
+     *
+     * @param string $widgetClass
+     * @param string|null $template
+     *
+     * @return static
+     */
+    public function widgetTemplate(string $widgetClass, ?string $template): self
+    {
+        $new = clone $this;
+
+        if (empty($template)) {
+            unset($new->widgetTemplates[$widgetClass]);
+        } else {
+            $new->widgetTemplates[$widgetClass] = $template;
+        }
+
         return $new;
     }
 

--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -85,6 +85,7 @@ final class Field extends Widget
     public function checkbox(array $attributes = [], bool $enclosedByLabel = true): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Checkbox::class] ?? $this->template;
         $checkbox = Checkbox::widget();
         $attributes['type'] = self::TYPE_CHECKBOX;
         $attributes = $new->setInputAttributes($attributes);
@@ -143,6 +144,7 @@ final class Field extends Widget
     public function checkboxList(array $attributes = [], array $items = [], array $itemsFromValues = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[CheckboxList::class] ?? $this->template;
         $checkboxList = CheckboxList::widget();
         $attributes = $new->setInputAttributes($attributes);
         /** @var bool|string|null */
@@ -214,6 +216,7 @@ final class Field extends Widget
     public function date(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Date::class] ?? $this->template;
         $attributes = $new->setInputAttributes($attributes);
 
         $new->parts['{input}'] = Date::widget()->config($new->getFormModel(), $new->attribute, $attributes)->render();
@@ -231,6 +234,7 @@ final class Field extends Widget
     public function datetime(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[DateTime::class] ?? $this->template;
         $attributes = $new->setInputAttributes($attributes);
 
         $new->parts['{input}'] = DateTime::widget()->config($new->getFormModel(), $new->attribute, $attributes)->render();
@@ -248,6 +252,7 @@ final class Field extends Widget
     public function datetimelocal(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[DateTimeLocal::class] ?? $this->template;
         $attributes = $new->setInputAttributes($attributes);
 
         $new->parts['{input}'] = DateTimeLocal::widget()
@@ -271,6 +276,7 @@ final class Field extends Widget
     public function email(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Email::class] ?? $this->template;
         $attributes['type'] = self::TYPE_EMAIL;
         $attributes = $new->setInputAttributes($attributes);
 
@@ -344,6 +350,7 @@ final class Field extends Widget
     public function file(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[File::class] ?? $this->template;
         $file = File::widget();
         $attributes = $new->setInputAttributes($attributes);
 
@@ -382,6 +389,7 @@ final class Field extends Widget
     public function hidden(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Hidden::class] ?? $this->template;
         $attributes['type'] = self::TYPE_HIDDEN;
         $attributes = $new->setInputAttributes($attributes);
 
@@ -450,6 +458,7 @@ final class Field extends Widget
     public function image(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Image::class] ?? $this->template;
         $image = Image::widget();
         $new->parts['{error}'] = '';
         $new->parts['{hint}'] = '';
@@ -512,6 +521,7 @@ final class Field extends Widget
     public function number(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Number::class] ?? $this->template;
         $attributes['type'] = self::TYPE_NUMBER;
         $attributes = $new->setInputAttributes($attributes);
 
@@ -534,6 +544,7 @@ final class Field extends Widget
     public function password(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Password::class] ?? $this->template;
         $attributes['type'] = self::TYPE_PASSWORD;
         $attributes = $new->setInputAttributes($attributes);
 
@@ -569,6 +580,7 @@ final class Field extends Widget
     public function radio(array $attributes = [], bool $enclosedByLabel = true): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Radio::class] ?? $this->template;
         $radio = Radio::widget();
         $attributes['type'] = self::TYPE_RADIO;
         $attributes = $new->setInputAttributes($attributes);
@@ -630,6 +642,7 @@ final class Field extends Widget
     public function radioList(array $attributes = [], array $items = [], array $itemsFromValues = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[RadioList::class] ?? $this->template;
         $radioList = RadioList::widget();
         $attributes = $new->setInputAttributes($attributes);
         /** @var bool|string|null */
@@ -712,6 +725,7 @@ final class Field extends Widget
     public function range(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Range::class] ?? $this->template;
         $range = Range::widget();
         $attributes['type'] = self::TYPE_NUMBER;
         $attributes = $new->setInputAttributes($attributes);
@@ -743,6 +757,7 @@ final class Field extends Widget
     public function resetButton(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[ResetButton::class] ?? $this->template;
         $reset = ResetButton::widget();
         $new->parts['{error}'] = '';
         $new->parts['{hint}'] = '';
@@ -809,6 +824,7 @@ final class Field extends Widget
     public function select(array $attributes = [], array $items = [], array $groups = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Select::class] ?? $this->template;
         $attributes['type'] = self::TYPE_SELECT;
         $attributes = $new->setInputAttributes($attributes);
         /** @var bool */
@@ -857,6 +873,7 @@ final class Field extends Widget
     public function submitButton(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[SubmitButton::class] ?? $this->template;
         $submit = SubmitButton::widget();
         $new->parts['{error}'] = '';
         $new->parts['{hint}'] = '';
@@ -899,6 +916,7 @@ final class Field extends Widget
     public function telephone(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Telephone::class] ?? $this->template;
         $attributes['type'] = self::TYPE_TEL;
         $attributes = $new->setInputAttributes($attributes);
 
@@ -921,6 +939,7 @@ final class Field extends Widget
     public function text(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Text::class] ?? $this->template;
         $attributes['type'] = self::TYPE_TEXT;
         $attributes = $new->setInputAttributes($attributes);
         $text = Text::widget();
@@ -949,6 +968,7 @@ final class Field extends Widget
     public function textArea(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[TextArea::class] ?? $this->template;
         $textArea = TextArea::widget();
         $attributes = $new->setInputAttributes($attributes);
 
@@ -981,6 +1001,7 @@ final class Field extends Widget
     public function url(array $attributes = []): self
     {
         $new = clone $this;
+        $new->template = $this->widgetTemplates[Url::class] ?? $this->template;
         $attributes['type'] = self::TYPE_URL;
         $attributes = $new->setInputAttributes($attributes);
 

--- a/tests/Widget/SeparateTemplateTest.php
+++ b/tests/Widget/SeparateTemplateTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\Widget;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Form\Widget\Field;
+use Yiisoft\Form\Widget\CheckboxList;
+use Yiisoft\Form\Tests\TestSupport\TestTrait;
+use Yiisoft\Form\Tests\TestSupport\Form\TypeForm;
+use Yiisoft\Widget\WidgetFactory;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Form\Widget\Text;
+use Yiisoft\Form\Widget\Label;
+use Yiisoft\Form\Widget\SubmitButton;
+use Yiisoft\Form\Widget\Number;
+use Yiisoft\Form\Widget\Url;
+use Yiisoft\Form\Widget\Telephone;
+
+final class SeparateTemplateTest extends TestCase
+{
+    use TestTrait;
+
+    private TypeForm $formModel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        WidgetFactory::initialize(new SimpleContainer(), []);
+        $this->createFormModel(TypeForm::class);
+    }
+
+    public function testSeparateTemplates(): void
+    {
+        $field = Field::widget()
+            ->template('{label}<div class="col-sm-10">{input}</div>')
+            ->widgetTemplates([
+                CheckboxList::class => '<div class="col-sm-10">{input}</div>',
+                SubmitButton::class => '<div class="col-sm-10 offset-sm-2">{input}</div>',
+            ]);
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                Label::widget()->config($this->formModel, 'toCamelCase')->render() .
+                '<div class="col-sm-10">' .
+                     Text::widget()->config($this->formModel, 'toCamelCase')->render() .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->config($this->formModel, 'toCamelCase')->text()->render())
+        );
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                '<div class="col-sm-10">' .
+                    str_replace("\n", '', CheckboxList::widget()->config($this->formModel, 'array')->render()) .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->config($this->formModel, 'array')->checkboxList()->render())
+        );
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                '<div class="col-sm-10 offset-sm-2">' .
+                    SubmitButton::widget()->id('test-id')->render() .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->submitButton(['id' => 'test-id'])->render())
+        );
+    }
+
+    public function testSeparateDropTemplates(): void
+    {
+        $field = Field::widget()
+            ->template('{label}<div class="col-sm-10">{input}</div>')
+            ->widgetTemplates([
+                Number::class => '<div class="custom-number-class">{input}</div>',
+                Url::class => '<div class="custom-url-class">{input}</div>',
+                Telephone::class => '<div class="custom-telephone-class">{input}</div>',
+            ]);
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                '<div class="custom-number-class">' .
+                     Number::widget()->config($this->formModel, 'number')->render() .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->config($this->formModel, 'number')->number()->render())
+        );
+
+        $field = $field->widgetTemplate(Number::class, null);
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                Label::widget()->config($this->formModel, 'number')->render() .
+                '<div class="col-sm-10">' .
+                     Number::widget()->config($this->formModel, 'number')->render() .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->config($this->formModel, 'number')->number()->render())
+        );
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                '<div class="custom-url-class">' .
+                    Url::widget()->config($this->formModel, 'toCamelCase')->render() .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->config($this->formModel, 'toCamelCase')->url()->render())
+        );
+
+        $field = $field->widgetTemplate(Url::class, null);
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                Label::widget()->config($this->formModel, 'toCamelCase')->render() .
+                '<div class="col-sm-10">' .
+                    Url::widget()->config($this->formModel, 'toCamelCase')->render() .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->config($this->formModel, 'toCamelCase')->url()->render())
+        );
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                '<div class="custom-telephone-class">' .
+                    Telephone::widget()->config($this->formModel, 'toCamelCase')->render() .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->config($this->formModel, 'toCamelCase')->telephone()->render())
+        );
+
+        $field = $field->widgetTemplate(Telephone::class, null);
+
+        $this->assertEqualsWithoutLE(
+            '<div>' .
+                Label::widget()->config($this->formModel, 'toCamelCase')->render() .
+                '<div class="col-sm-10">' .
+                    Telephone::widget()->config($this->formModel, 'toCamelCase')->render() .
+                '</div>' .
+            '</div>',
+            str_replace("\n", '', $field->config($this->formModel, 'toCamelCase')->telephone()->render())
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Good day. After widget has own config (widgets.php) became possible set/change base config for all widgets in all pages - and it's cool. But today we can't set template in field for current widget. I used that trick

```
Field::class => [
    'template()' => [
        '{label}<div class="col-sm-10">{input}{error}</div>'
    ],
    ****
],

'ButtonField' => [
    'class' => Field::class,
    'template()' => [
        '<div class="offset-sm-2 col-sm-10 text-center text-sm-start">{input}</div>'
    ],
    ****
],

// In some view
$buttonField = Widget::widget('ButtonField');
```
It's works, but uncomfortable (no autocopletetion in IDE and etc).

So that PR maybe resolve that problem. With this we can write that base config:

```
Field::class => [
    'template()' => [
        '{label}<div class="col-sm-10">{input}{error}</div>'
    ],
    'widgetTemplates()' => [
           [
               SubmitButton::class => '<div class="offset-sm-2 col-sm-10 text-center text-sm-start">{input}</div>',
               OtherFormWidget::class => '<div class="custom-class">{input}</div>'
           ]
     ]
],  

```
If that wil be interesting - i will be think about `inputClass`, `containerClass`. Thanks

Little remark/issue - maybe separate `submitButton`/`submitInput`, `resetButton`/`resetInput` methods? First - render more flexible button tag. Second - submit input tag (as current submitButton method)

