### PR TITLE
Add method `onlyAttributes()` to `ErrorSummary::class`.

### DIFF
--- a/docs/error-summary.md
+++ b/docs/error-summary.md
@@ -68,11 +68,11 @@ use Yiisoft\Form\Widget\Text;
 ?>
 
 <?= Form::widget()->action('widgets')->csrf($csrf)->begin(); ?>
-    <?= Text::widget()->config($formModel, 'name') ?>
-    <?= Text::widget()->config($formModel, 'email') ?>
+    <?= Text::widget()->for($formModel, 'name') ?>
+    <?= Text::widget()->for($formModel, 'email') ?>
     <?= ErrorSummary::widget()->model($formModel) ?>
     <hr class="mt-3">
-    <?= Field::widget()->submitButton(['class' => 'button is-block is-info is-fullwidth', 'value' => 'Save']); ?>
+    <?= SubmitButton::widget()->attributes(['class' => 'button is-block is-info is-fullwidth'])->value('Save') ?>
 <?= Form::end(); ?>
 ```
 
@@ -81,32 +81,28 @@ That would generate the following code before validation:
 ```html
 <form action="widgets" method="POST" _csrf="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
     <input type="hidden" name="_csrf" value="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
-    <input type="text" id="testform-name" name="TestForm[name]">
+    <input type="text" id="testform-name" name="TestForm[name]" minlength="4">
     <input type="text" id="testform-email" name="TestForm[email]">
-    <div style="display:none"><p>Please fix the following errors:</p><ul></ul></div>
     <hr class="mt-3">
-    <div>
-        <input type="submit" id="submit-14082948982001" class="button is-block is-info is-fullwidth" name="submit-14082948982001" value="Save">
-    </div>
+    <input type="submit" id="w1-submit" class="button is-block is-info is-fullwidth" name="w1-submit" value="Save">
 </form>
 ```
 
 That would generate the following code after validation:
 ```html
-<form action="widgets" method="POST" _csrf="9moR1LM6d8JXgqYRLTD_ba2D-fQNRSyXTddnFUQIU1XFXWi61m408iDU_mhMaJ4127TIjk4fQ-MLsDUhDUkZPg==">
-    <input type="hidden" name="_csrf" value="9moR1LM6d8JXgqYRLTD_ba2D-fQNRSyXTddnFUQIU1XFXWi61m408iDU_mhMaJ4127TIjk4fQ-MLsDUhDUkZPg==">
-    <input type="text" id="testform-name" name="TestForm[name]">
+<form action="widgets" method="POST" _csrf="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
+    <input type="hidden" name="_csrf" value="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
+    <input type="text" id="testform-name" name="TestForm[name]" minlength="4">
     <input type="text" id="testform-email" name="TestForm[email]">
-    <div><p>Please fix the following errors:</p>
+    <div>
+        <p>Please fix the following errors:</p>
         <ul>
             <li>This value is not a valid email address.</li>
             <li>Is too short.</li>
         </ul>
     </div>
     <hr class="mt-3">
-    <div>
-        <input type="submit" id="submit-14687568353001" class="button is-block is-info is-fullwidth" name="submit-14687568353001" value="Save">
-    </div>
+    <input type="submit" id="w1-submit" class="button is-block is-info is-fullwidth" name="w1-submit" value="Save">
 </form>
 ```
 
@@ -132,8 +128,8 @@ use Yiisoft\Form\Widget\Text;
 ?>
 
 <?= Form::widget()->action('widgets')->csrf($csrf)->begin(); ?>
-    <?= Text::widget()->config($formModel, 'name') ?>
-    <?= Text::widget()->config($formModel, 'email') ?>
+    <?= Text::widget()->for($formModel, 'name') ?>
+    <?= Text::widget()->for($formModel, 'email') ?>
     <?= ErrorSummary::widget()
         ->attributes(['class' => 'has-text-danger'])
         ->footer('Custom Footer:')
@@ -141,44 +137,74 @@ use Yiisoft\Form\Widget\Text;
         ->model($formModel)
     ?>
     <hr class="mt-3">
-    <?= Field::widget()->submitButton(['class' => 'button is-block is-info is-fullwidth', 'value' => 'Save']); ?>
+    <?= SubmitButton::widget()->attributes(['class' => 'button is-block is-info is-fullwidth'])->value('Save') ?>
 <?= Form::end(); ?>
-```
-
-That would generate the following code before validation:
-
-```html
-<form action="widgets" method="POST" _csrf="SNh_ZumgopPv9wpiFCMw3IioeIbaQ9w54dYmh0XRanl77wYIjPTho5ihUht1e1GE_p9J_JkZs02nsXSzDJAgEg==">    
-    <input type="hidden" name="_csrf" value="SNh_ZumgopPv9wpiFCMw3IioeIbaQ9w54dYmh0XRanl77wYIjPTho5ihUht1e1GE_p9J_JkZs02nsXSzDJAgEg==">
-    <input type="text" id="testform-name" name="TestForm[name]">
-    <input type="text" id="testform-email" name="TestForm[email]">
-    <div class="has-text-danger" style="display:none">Custom Header:<ul></ul>Custom Footer:</div>
-    <hr class="mt-3">
-    <div>
-        <input type="submit" id="submit-20289061442001" class="button is-block is-info is-fullwidth" name="submit-20289061442001" value="Save">
-    </div>
-</form>
 ```
 
 That would generate the following code after validation:
 
 ```html
-<form action="widgets" method="POST" _csrf="PwqhEiBBULqjUwjVQFBIGDt2iral9LmaJNOkfEJe-BcMPdh8RRUTitQFUKwhCClATUG7zOau1u5itPZICx-yfA==">
-    <input type="hidden" name="_csrf" value="PwqhEiBBULqjUwjVQFBIGDt2iral9LmaJNOkfEJe-BcMPdh8RRUTitQFUKwhCClATUG7zOau1u5itPZICx-yfA==">
-    <input type="text" id="testform-name" name="TestForm[name]">
+<form action="widgets" method="POST" _csrf="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
+    <input type="hidden" name="_csrf" value="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
+    <input type="text" id="testform-name" name="TestForm[name]" minlength="4">
     <input type="text" id="testform-email" name="TestForm[email]">
     <div class="has-text-danger">
-        Custom Header:
+        <p>Custom Header:</p>
         <ul>
             <li>This value is not a valid email address.</li>
             <li>Is too short.</li>
         </ul>
-        Custom Footer:
+        <p>Custom Footer:</p>
     </div>
     <hr class="mt-3">
-    <div>
-        <input type="submit" id="submit-21602903539001" class="button is-block is-info is-fullwidth" name="submit-21602903539001" value="Save">
+    <input type="submit" id="w1-submit" class="button is-block is-info is-fullwidth" name="w1-submit" value="Save">
+</form>
+```
+
+### Exclude attributes
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Form\FormModelInterface;
+use Yiisoft\Form\Widget\ErrorSummary;
+use Yiisoft\Form\Widget\Field;
+use Yiisoft\Form\Widget\Form;
+use Yiisoft\Form\Widget\Text;
+
+/**
+ * @var FormModelInterface $data
+ * @var object $csrf
+ */
+?>
+
+<?= Form::widget()->action('widgets')->csrf($csrf)->begin(); ?>
+    <?= Text::widget()->for($formModel, 'name') ?>
+    <?= Text::widget()->for($formModel, 'email') ?>
+    <?= ErrorSummary::widget()->attributes(['class' => 'has-text-danger'])->excludeAttributes(['name'])->model($formModel) ?>
+    <hr class="mt-3">
+    <?= Field::widget()->submitButton(['class' => 'button is-block is-info is-fullwidth', 'value' => 'Save']); ?>
+<?= Form::end(); ?>
+```
+
+
+That would generate the following code after validation:
+
+```html
+<form action="widgets" method="POST" _csrf="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
+    <input type="hidden" name="_csrf" value="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
+    <input type="text" id="testform-name" name="TestForm[name]" minlength="4">
+    <input type="text" id="testform-email" name="TestForm[email]">
+    <div class="has-text-danger">
+        <p>Please fix the following errors:</p>
+        <ul>
+            <li>This value is not a valid email address.</li>
+        </ul>
     </div>
+    <hr class="mt-3">
+    <input type="submit" id="w1-submit" class="button is-block is-info is-fullwidth" name="w1-submit" value="Save">
 </form>
 ```
 
@@ -188,6 +214,7 @@ Method | Description | Default
 -------|-------------|---------
 `attributes(array $value)` | Sets the HTML attributes for the error summary. | `[]`
 `encode(bool $value)` | Whether to encode the error summary. | `true`
+`excludeAttributes(array $value)` | Exclude specific attributes from the error summary. | `[]`
 `footer(string $value)` | Set the footer text for the error summary. | `''`
 `header(string $value)` | Set the header text for the error summary. | `''`
 `model(FormModelInterface $formModel)` | Set the model for the error summary. | `null`

--- a/docs/error-summary.md
+++ b/docs/error-summary.md
@@ -183,7 +183,7 @@ use Yiisoft\Form\Widget\Text;
 <?= Form::widget()->action('widgets')->csrf($csrf)->begin(); ?>
     <?= Text::widget()->for($formModel, 'name') ?>
     <?= Text::widget()->for($formModel, 'email') ?>
-    <?= ErrorSummary::widget()->attributes(['class' => 'has-text-danger'])->excludeAttributes(['name'])->model($formModel) ?>
+    <?= ErrorSummary::widget()->attributes(['class' => 'has-text-danger'])->excludeAttributes('name')->model($formModel) ?>
     <hr class="mt-3">
     <?= Field::widget()->submitButton(['class' => 'button is-block is-info is-fullwidth', 'value' => 'Save']); ?>
 <?= Form::end(); ?>

--- a/docs/error-summary.md
+++ b/docs/error-summary.md
@@ -161,7 +161,7 @@ That would generate the following code after validation:
 </form>
 ```
 
-### Exclude attributes
+### Only attributes
 
 ```php
 <?php
@@ -183,7 +183,7 @@ use Yiisoft\Form\Widget\Text;
 <?= Form::widget()->action('widgets')->csrf($csrf)->begin(); ?>
     <?= Text::widget()->for($formModel, 'name') ?>
     <?= Text::widget()->for($formModel, 'email') ?>
-    <?= ErrorSummary::widget()->attributes(['class' => 'has-text-danger'])->excludeAttributes('name')->model($formModel) ?>
+    <?= ErrorSummary::widget()->attributes(['class' => 'has-text-danger'])->onlyAttributes('name')->model($formModel) ?>
     <hr class="mt-3">
     <?= Field::widget()->submitButton(['class' => 'button is-block is-info is-fullwidth', 'value' => 'Save']); ?>
 <?= Form::end(); ?>
@@ -214,9 +214,9 @@ Method | Description | Default
 -------|-------------|---------
 `attributes(array $value)` | Sets the HTML attributes for the error summary. | `[]`
 `encode(bool $value)` | Whether to encode the error summary. | `true`
-`excludeAttributes(array $value)` | Exclude specific attributes from the error summary. | `[]`
 `footer(string $value)` | Set the footer text for the error summary. | `''`
 `header(string $value)` | Set the header text for the error summary. | `''`
 `model(FormModelInterface $formModel)` | Set the model for the error summary. | `null`
 `showAllErrors(bool $value)` | Whether to show all errors. | `false`
-`function tag(string $value)` | Set the container tag name for the error summary. | `'div'`
+`onlyAttributes(array $value)` | Specific attributes to be included in error summary. | `''`
+`tag(string $value)` | Set the container tag name for the error summary. | `'div'`

--- a/docs/error-summary.md
+++ b/docs/error-summary.md
@@ -183,7 +183,7 @@ use Yiisoft\Form\Widget\Text;
 <?= Form::widget()->action('widgets')->csrf($csrf)->begin(); ?>
     <?= Text::widget()->for($formModel, 'name') ?>
     <?= Text::widget()->for($formModel, 'email') ?>
-    <?= ErrorSummary::widget()->attributes(['class' => 'has-text-danger'])->onlyAttributes('name')->model($formModel) ?>
+    <?= ErrorSummary::widget()->attributes(['class' => 'has-text-danger'])->onlyAttributes('email')->model($formModel) ?>
     <hr class="mt-3">
     <?= Field::widget()->submitButton(['class' => 'button is-block is-info is-fullwidth', 'value' => 'Save']); ?>
 <?= Form::end(); ?>

--- a/src/FormErrors.php
+++ b/src/FormErrors.php
@@ -33,9 +33,15 @@ final class FormErrors implements FormErrorsInterface
         return $this->attributesErrors[$attribute] ?? [];
     }
 
-    public function getErrorSummary(): array
+    public function getErrorSummary(array $onlyAttributes = []): array
     {
-        return $this->renderErrorSummary($this->getAllErrors());
+        $errors = $this->getAllErrors();
+
+        if ($onlyAttributes !== []) {
+            $errors = array_intersect_key($errors, array_flip($onlyAttributes));
+        }
+
+        return $this->renderErrorSummary($errors);
     }
 
     public function getErrorSummaryFirstErrors(): array

--- a/src/FormErrorsInterface.php
+++ b/src/FormErrorsInterface.php
@@ -64,12 +64,14 @@ interface FormErrorsInterface
     /**
      * Returns errors for all attributes as a one-dimensional array.
      *
+     * @param array $onlyAttributes List of attributes to return errors.
+     *
      * @return array errors for all attributes as a one-dimensional array. Empty array is returned if no error.
      *
      * {@see getErrors()}
      * {@see getFirstErrors(){}
      */
-    public function getErrorSummary(): array;
+    public function getErrorSummary(array $onlyAttributes): array;
 
     /**
      * Returns the first error of every attribute in the collection.

--- a/src/Helper/HtmlFormErrors.php
+++ b/src/Helper/HtmlFormErrors.php
@@ -50,12 +50,13 @@ final class HtmlFormErrors
      * Returns the errors for all attributes as a one-dimensional array.
      *
      * @param FormModelInterface $formModel the form object.
+     * @param array $onlyAttributes list of attributes whose errors should be returned.
      *
      * @return array errors for all attributes as a one-dimensional array. Empty array is returned if no error.
      */
-    public static function getErrorSummary(FormModelInterface $formModel): array
+    public static function getErrorSummary(FormModelInterface $formModel, array $onlyAttributes = []): array
     {
-        return $formModel->getFormErrors()->getErrorSummary();
+        return $formModel->getFormErrors()->getErrorSummary($onlyAttributes);
     }
 
     /**

--- a/src/Widget/ErrorSummary.php
+++ b/src/Widget/ErrorSummary.php
@@ -72,7 +72,7 @@ final class ErrorSummary extends Widget
      *
      * @return static
      */
-    public function excludeAttributes(array $values): self
+    public function excludeAttributes(string ...$values): self
     {
         $new = clone $this;
         $new->excludeAttributes = $values;

--- a/src/Widget/ErrorSummary.php
+++ b/src/Widget/ErrorSummary.php
@@ -25,7 +25,7 @@ final class ErrorSummary extends Widget
 {
     private array $attributes = [];
     private bool $encode = true;
-    private array $firstErrorsOfAttributes = [];
+    private array $onlyAttributes = [];
     private FormModelInterface $formModel;
     private string $footer = '';
     private array $footerAttributes = [];
@@ -62,21 +62,6 @@ final class ErrorSummary extends Widget
     {
         $new = clone $this;
         $new->encode = $value;
-        return $new;
-    }
-
-    /**
-     * Specific attributes to be filtered out when rendering the error summary.
-     * Attributes can only be filtered when showAllErrors is `false`.
-     *
-     * @param array $values The attributes to be included in error summary.
-     *
-     * @return static
-     */
-    public function firstErrorsOfAttributes(string ...$values): self
-    {
-        $new = clone $this;
-        $new->firstErrorsOfAttributes = $values;
         return $new;
     }
 
@@ -169,6 +154,20 @@ final class ErrorSummary extends Widget
     }
 
     /**
+     * Specific attributes to be filtered out when rendering the error summary.
+     *
+     * @param array $values The attributes to be included in error summary.
+     *
+     * @return static
+     */
+    public function onlyAttributes(string ...$values): self
+    {
+        $new = clone $this;
+        $new->onlyAttributes = $values;
+        return $new;
+    }
+
+    /**
      * Set the container tag name for the error summary.
      *
      * Empty to render error messages without container {@see Html::tag()}.
@@ -195,9 +194,9 @@ final class ErrorSummary extends Widget
         $errorMessages = [];
 
         if ($this->showAllErrors) {
-            $errors = HtmlFormErrors::getErrorSummary($this->formModel);
-        } elseif ($this->firstErrorsOfAttributes !== []) {
-            $errors = array_intersect_key($errors, array_flip($this->firstErrorsOfAttributes));
+            $errors = HtmlFormErrors::getErrorSummary($this->formModel, $this->onlyAttributes);
+        } elseif ($this->onlyAttributes !== []) {
+            $errors = array_intersect_key($errors, array_flip($this->onlyAttributes));
         }
 
         /**

--- a/src/Widget/ErrorSummary.php
+++ b/src/Widget/ErrorSummary.php
@@ -25,12 +25,12 @@ final class ErrorSummary extends Widget
 {
     private array $attributes = [];
     private bool $encode = true;
+    private array $firstErrorsOfAttributes = [];
     private FormModelInterface $formModel;
     private string $footer = '';
     private array $footerAttributes = [];
     private string $header = 'Please fix the following errors:';
     private array $headerAttributes = [];
-    private array $onlyAttributes = [];
     private bool $showAllErrors = false;
     /** @psalm-param non-empty-string */
     private string $tag = 'div';
@@ -62,6 +62,21 @@ final class ErrorSummary extends Widget
     {
         $new = clone $this;
         $new->encode = $value;
+        return $new;
+    }
+
+    /**
+     * Specific attributes to be filtered out when rendering the error summary.
+     * Attributes can only be filtered when showAllErrors is `false`.
+     *
+     * @param array $values The attributes to be included in error summary.
+     *
+     * @return static
+     */
+    public function firstErrorsOfAttributes(string ...$values): self
+    {
+        $new = clone $this;
+        $new->firstErrorsOfAttributes = $values;
         return $new;
     }
 
@@ -154,20 +169,6 @@ final class ErrorSummary extends Widget
     }
 
     /**
-     * Specific attributes to be included in error summary.
-     *
-     * @param array $values The attributes to be included in error summary.
-     *
-     * @return static
-     */
-    public function onlyAttributes(string ...$values): self
-    {
-        $new = clone $this;
-        $new->onlyAttributes = $values;
-        return $new;
-    }
-
-    /**
      * Set the container tag name for the error summary.
      *
      * Empty to render error messages without container {@see Html::tag()}.
@@ -195,8 +196,8 @@ final class ErrorSummary extends Widget
 
         if ($this->showAllErrors) {
             $errors = HtmlFormErrors::getErrorSummary($this->formModel);
-        } elseif ($this->onlyAttributes !== []) {
-            $errors = array_intersect_key($errors, array_flip($this->onlyAttributes));
+        } elseif ($this->firstErrorsOfAttributes !== []) {
+            $errors = array_intersect_key($errors, array_flip($this->firstErrorsOfAttributes));
         }
 
         /**

--- a/src/Widget/ErrorSummary.php
+++ b/src/Widget/ErrorSummary.php
@@ -193,7 +193,7 @@ final class ErrorSummary extends Widget
         $errors = HtmlFormErrors::getErrorSummaryFirstErrors($this->formModel);
         $errorMessages = [];
 
-        if ($this->showAllErrors && $this->onlyAttributes === []) {
+        if ($this->showAllErrors) {
             $errors = HtmlFormErrors::getErrorSummary($this->formModel);
         } elseif ($this->onlyAttributes !== []) {
             $errors = array_intersect_key($errors, array_flip($this->onlyAttributes));

--- a/src/Widget/ErrorSummary.php
+++ b/src/Widget/ErrorSummary.php
@@ -25,6 +25,7 @@ final class ErrorSummary extends Widget
 {
     private array $attributes = [];
     private bool $encode = true;
+    private array $excludeAttributes = [];
     private FormModelInterface $formModel;
     private string $footer = '';
     private array $footerAttributes = [];
@@ -61,6 +62,20 @@ final class ErrorSummary extends Widget
     {
         $new = clone $this;
         $new->encode = $value;
+        return $new;
+    }
+
+    /**
+     * Exclude specific attributes from the error summary.
+     *
+     * @param array $values The attributes to exclude.
+     *
+     * @return static
+     */
+    public function excludeAttributes(array $values): self
+    {
+        $new = clone $this;
+        $new->excludeAttributes = $values;
         return $new;
     }
 
@@ -178,8 +193,10 @@ final class ErrorSummary extends Widget
         $errors = HtmlFormErrors::getErrorSummaryFirstErrors($this->formModel);
         $errorMessages = [];
 
-        if ($this->showAllErrors) {
+        if ($this->showAllErrors && $this->excludeAttributes === []) {
             $errors = HtmlFormErrors::getErrorSummary($this->formModel);
+        } elseif ($this->excludeAttributes !== []) {
+            $errors = array_diff_key($errors, array_flip($this->excludeAttributes));
         }
 
         /**

--- a/src/Widget/ErrorSummary.php
+++ b/src/Widget/ErrorSummary.php
@@ -25,12 +25,12 @@ final class ErrorSummary extends Widget
 {
     private array $attributes = [];
     private bool $encode = true;
-    private array $excludeAttributes = [];
     private FormModelInterface $formModel;
     private string $footer = '';
     private array $footerAttributes = [];
     private string $header = 'Please fix the following errors:';
     private array $headerAttributes = [];
+    private array $onlyAttributes = [];
     private bool $showAllErrors = false;
     /** @psalm-param non-empty-string */
     private string $tag = 'div';
@@ -62,20 +62,6 @@ final class ErrorSummary extends Widget
     {
         $new = clone $this;
         $new->encode = $value;
-        return $new;
-    }
-
-    /**
-     * Exclude specific attributes from the error summary.
-     *
-     * @param array $values The attributes to exclude.
-     *
-     * @return static
-     */
-    public function excludeAttributes(string ...$values): self
-    {
-        $new = clone $this;
-        $new->excludeAttributes = $values;
         return $new;
     }
 
@@ -168,6 +154,20 @@ final class ErrorSummary extends Widget
     }
 
     /**
+     * Specific attributes to be included in error summary.
+     *
+     * @param array $values The attributes to be included in error summary.
+     *
+     * @return static
+     */
+    public function onlyAttributes(string ...$values): self
+    {
+        $new = clone $this;
+        $new->onlyAttributes = $values;
+        return $new;
+    }
+
+    /**
      * Set the container tag name for the error summary.
      *
      * Empty to render error messages without container {@see Html::tag()}.
@@ -193,10 +193,10 @@ final class ErrorSummary extends Widget
         $errors = HtmlFormErrors::getErrorSummaryFirstErrors($this->formModel);
         $errorMessages = [];
 
-        if ($this->showAllErrors && $this->excludeAttributes === []) {
+        if ($this->showAllErrors && $this->onlyAttributes === []) {
             $errors = HtmlFormErrors::getErrorSummary($this->formModel);
-        } elseif ($this->excludeAttributes !== []) {
-            $errors = array_diff_key($errors, array_flip($this->excludeAttributes));
+        } elseif ($this->onlyAttributes !== []) {
+            $errors = array_intersect_key($errors, array_flip($this->onlyAttributes));
         }
 
         /**

--- a/tests/Helper/HtmlFormErrorsTest.php
+++ b/tests/Helper/HtmlFormErrorsTest.php
@@ -97,4 +97,20 @@ final class HtmlFormErrorsTest extends TestCase
         $this->assertFalse($validator->validate($formModel)->isValid());
         $this->assertTrue(HtmlFormErrors::hasErrors($formModel));
     }
+
+    public function testGetErrorSummaryOnlyAttributes(): void
+    {
+        $formModel = new LoginForm();
+        $validator = $this->createValidatorMock();
+        $this->assertTrue($formModel->load($this->data));
+        $this->assertFalse($validator->validate($formModel)->isValid());
+        $this->assertSame(
+            ['This value is not a valid email address.'],
+            HtmlFormErrors::getErrorSummary($formModel, ['login']),
+        );
+        $this->assertSame(
+            ['Is too short.'],
+            HtmlFormErrors::getErrorSummary($formModel, ['password']),
+        );
+    }
 }

--- a/tests/Widget/ErrorSummaryTest.php
+++ b/tests/Widget/ErrorSummaryTest.php
@@ -68,25 +68,45 @@ final class ErrorSummaryTest extends TestCase
                 </div>
                 HTML,
             ],
-            // Set filter attributes.
+            // Set only attributes with showAllErros its `true`.
             [
                 'jac',
                 'jack@.com',
                 'A258*f',
                 [],
-                'Custom header',
+                '',
                 ['class' => 'text-danger'],
-                'Custom footer',
+                '',
                 ['class' => 'text-primary'],
-                false,
+                true,
                 ['name'],
                 <<<HTML
                 <div>
-                <p class="text-danger">Custom header</p>
+                <p class="text-danger">Please fix the following errors:</p>
                 <ul>
                 <li>Is too short.</li>
                 </ul>
-                <p class="text-primary">Custom footer</p>
+                </div>
+                HTML,
+            ],
+            // Set only attributes with showAllErros `false`.
+            [
+                'jac',
+                'jack@.com',
+                'A258*f',
+                [],
+                '',
+                ['class' => 'text-danger'],
+                '',
+                ['class' => 'text-primary'],
+                false,
+                ['password'],
+                <<<HTML
+                <div>
+                <p class="text-danger">Please fix the following errors:</p>
+                <ul>
+                <li>Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters.</li>
+                </ul>
                 </div>
                 HTML,
             ],
@@ -101,10 +121,10 @@ final class ErrorSummaryTest extends TestCase
         $errorSummary = ErrorSummary::widget();
         $this->assertNotSame($errorSummary, $errorSummary->attributes([]));
         $this->assertNotSame($errorSummary, $errorSummary->encode(false));
-        $this->assertNotSame($errorSummary, $errorSummary->firstErrorsOfAttributes(''));
         $this->assertNotSame($errorSummary, $errorSummary->footer(''));
         $this->assertNotSame($errorSummary, $errorSummary->header(''));
         $this->assertNotSame($errorSummary, $errorSummary->model(new PersonalForm()));
+        $this->assertNotSame($errorSummary, $errorSummary->onlyAttributes(''));
         $this->assertNotSame($errorSummary, $errorSummary->showAllErrors(false));
         $this->assertNotSame($errorSummary, $errorSummary->tag('div'));
     }
@@ -121,7 +141,7 @@ final class ErrorSummaryTest extends TestCase
      * @param string $footer
      * @param array $footerAttributes
      * @param bool $showAllErrors
-     * @param array $firstErrorsOfAttributes
+     * @param array $onlyAttributes
      * @param string $expected
      *
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
@@ -136,7 +156,7 @@ final class ErrorSummaryTest extends TestCase
         string $footer,
         array $footerAttributes,
         bool $showAllErrors,
-        array $firstErrorsOfAttributes,
+        array $onlyAttributes,
         string $expected
     ): void {
         $formModel = new PersonalForm();
@@ -156,7 +176,7 @@ final class ErrorSummaryTest extends TestCase
 
         $errorSummary = ErrorSummary::widget()
             ->attributes($attributes)
-            ->firstErrorsOfAttributes(...$firstErrorsOfAttributes)
+            ->onlyAttributes(...$onlyAttributes)
             ->footer($footer)
             ->footerAttributes($footerAttributes)
             ->headerAttributes($headerAttributes)

--- a/tests/Widget/ErrorSummaryTest.php
+++ b/tests/Widget/ErrorSummaryTest.php
@@ -32,6 +32,7 @@ final class ErrorSummaryTest extends TestCase
                 '',
                 [],
                 true,
+                [],
                 <<<HTML
                 <div>
                 <p class="text-danger">Please fix the following errors:</p>
@@ -54,6 +55,7 @@ final class ErrorSummaryTest extends TestCase
                 'Custom footer',
                 ['class' => 'text-primary'],
                 true,
+                [],
                 <<<HTML
                 <div>
                 <p class="text-danger">Custom header</p>
@@ -61,6 +63,28 @@ final class ErrorSummaryTest extends TestCase
                 <li>Is too short.</li>
                 <li>This value is not a valid email address.</li>
                 <li>Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters.</li>
+                </ul>
+                <p class="text-primary">Custom footer</p>
+                </div>
+                HTML,
+            ],
+            // Set filter attributes.
+            [
+                'jac',
+                'jack@.com',
+                'A258*f',
+                [],
+                'Custom header',
+                ['class' => 'text-danger'],
+                'Custom footer',
+                ['class' => 'text-primary'],
+                true,
+                ['email', 'password'],
+                <<<HTML
+                <div>
+                <p class="text-danger">Custom header</p>
+                <ul>
+                <li>Is too short.</li>
                 </ul>
                 <p class="text-primary">Custom footer</p>
                 </div>
@@ -96,6 +120,7 @@ final class ErrorSummaryTest extends TestCase
      * @param string $footer
      * @param array $footerAttributes
      * @param bool $showAllErrors
+     * @param array $excludeAttributes
      * @param string $expected
      *
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
@@ -110,6 +135,7 @@ final class ErrorSummaryTest extends TestCase
         string $footer,
         array $footerAttributes,
         bool $showAllErrors,
+        array $excludeAttributes,
         string $expected
     ): void {
         $formModel = new PersonalForm();
@@ -129,10 +155,11 @@ final class ErrorSummaryTest extends TestCase
 
         $errorSummary = ErrorSummary::widget()
             ->attributes($attributes)
-            ->model($formModel)
+            ->excludeAttributes($excludeAttributes)
             ->footer($footer)
             ->footerAttributes($footerAttributes)
             ->headerAttributes($headerAttributes)
+            ->model($formModel)
             ->showAllErrors($showAllErrors);
 
         $errorSummary = $header !== '' ? $errorSummary->header($header) : $errorSummary;

--- a/tests/Widget/ErrorSummaryTest.php
+++ b/tests/Widget/ErrorSummaryTest.php
@@ -79,7 +79,7 @@ final class ErrorSummaryTest extends TestCase
                 'Custom footer',
                 ['class' => 'text-primary'],
                 true,
-                ['email', 'password'],
+                ['name'],
                 <<<HTML
                 <div>
                 <p class="text-danger">Custom header</p>
@@ -105,6 +105,7 @@ final class ErrorSummaryTest extends TestCase
         $this->assertNotSame($errorSummary, $errorSummary->header(''));
         $this->assertNotSame($errorSummary, $errorSummary->model(new PersonalForm()));
         $this->assertNotSame($errorSummary, $errorSummary->showAllErrors(false));
+        $this->assertNotSame($errorSummary, $errorSummary->onlyAttributes(''));
         $this->assertNotSame($errorSummary, $errorSummary->tag('div'));
     }
 
@@ -120,7 +121,7 @@ final class ErrorSummaryTest extends TestCase
      * @param string $footer
      * @param array $footerAttributes
      * @param bool $showAllErrors
-     * @param array $excludeAttributes
+     * @param array $onlyAttributes
      * @param string $expected
      *
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
@@ -135,7 +136,7 @@ final class ErrorSummaryTest extends TestCase
         string $footer,
         array $footerAttributes,
         bool $showAllErrors,
-        array $excludeAttributes,
+        array $onlyAttributes,
         string $expected
     ): void {
         $formModel = new PersonalForm();
@@ -155,7 +156,7 @@ final class ErrorSummaryTest extends TestCase
 
         $errorSummary = ErrorSummary::widget()
             ->attributes($attributes)
-            ->excludeAttributes(...$excludeAttributes)
+            ->onlyAttributes(...$onlyAttributes)
             ->footer($footer)
             ->footerAttributes($footerAttributes)
             ->headerAttributes($headerAttributes)

--- a/tests/Widget/ErrorSummaryTest.php
+++ b/tests/Widget/ErrorSummaryTest.php
@@ -101,11 +101,11 @@ final class ErrorSummaryTest extends TestCase
         $errorSummary = ErrorSummary::widget();
         $this->assertNotSame($errorSummary, $errorSummary->attributes([]));
         $this->assertNotSame($errorSummary, $errorSummary->encode(false));
+        $this->assertNotSame($errorSummary, $errorSummary->firstErrorsOfAttributes(''));
         $this->assertNotSame($errorSummary, $errorSummary->footer(''));
         $this->assertNotSame($errorSummary, $errorSummary->header(''));
         $this->assertNotSame($errorSummary, $errorSummary->model(new PersonalForm()));
         $this->assertNotSame($errorSummary, $errorSummary->showAllErrors(false));
-        $this->assertNotSame($errorSummary, $errorSummary->onlyAttributes(''));
         $this->assertNotSame($errorSummary, $errorSummary->tag('div'));
     }
 
@@ -121,7 +121,7 @@ final class ErrorSummaryTest extends TestCase
      * @param string $footer
      * @param array $footerAttributes
      * @param bool $showAllErrors
-     * @param array $onlyAttributes
+     * @param array $firstErrorsOfAttributes
      * @param string $expected
      *
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
@@ -136,7 +136,7 @@ final class ErrorSummaryTest extends TestCase
         string $footer,
         array $footerAttributes,
         bool $showAllErrors,
-        array $onlyAttributes,
+        array $firstErrorsOfAttributes,
         string $expected
     ): void {
         $formModel = new PersonalForm();
@@ -156,7 +156,7 @@ final class ErrorSummaryTest extends TestCase
 
         $errorSummary = ErrorSummary::widget()
             ->attributes($attributes)
-            ->onlyAttributes(...$onlyAttributes)
+            ->firstErrorsOfAttributes(...$firstErrorsOfAttributes)
             ->footer($footer)
             ->footerAttributes($footerAttributes)
             ->headerAttributes($headerAttributes)

--- a/tests/Widget/ErrorSummaryTest.php
+++ b/tests/Widget/ErrorSummaryTest.php
@@ -78,7 +78,7 @@ final class ErrorSummaryTest extends TestCase
                 ['class' => 'text-danger'],
                 'Custom footer',
                 ['class' => 'text-primary'],
-                true,
+                false,
                 ['name'],
                 <<<HTML
                 <div>

--- a/tests/Widget/ErrorSummaryTest.php
+++ b/tests/Widget/ErrorSummaryTest.php
@@ -155,7 +155,7 @@ final class ErrorSummaryTest extends TestCase
 
         $errorSummary = ErrorSummary::widget()
             ->attributes($attributes)
-            ->excludeAttributes($excludeAttributes)
+            ->excludeAttributes(...$excludeAttributes)
             ->footer($footer)
             ->footerAttributes($footerAttributes)
             ->headerAttributes($headerAttributes)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Example: exclude attribute `name` in `ErrorSummary::class`.
```php
<?= Form::widget()->action('widgets')->csrf($csrf)->begin(); ?>
    <?= Text::widget()->for($formModel, 'name') ?>
    <?= Text::widget()->for($formModel, 'email') ?>
    <?= ErrorSummary::widget()->attributes(['class' => 'has-text-danger'])->excludeAttributes('name')->model($formModel) ?>
    <hr class="mt-3">
    <?= Field::widget()->submitButton(['class' => 'button is-block is-info is-fullwidth', 'value' => 'Save']); ?>
<?= Form::end(); ?>
````

Code generate:
```HTML
<form action="widgets" method="POST" _csrf="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
    <input type="hidden" name="_csrf" value="vWob09HzPhcTDuhOHVU71VJQAAymEm2Hysn_8QN1Y8qOXWK9tKd9J2RYsDd8DVqNJGcxduVIAvOMrq3FSjQpoQ==">
    <input type="text" id="testform-name" name="TestForm[name]" minlength="4">
    <input type="text" id="testform-email" name="TestForm[email]">
    <div class="has-text-danger">
        <p>Please fix the following errors:</p>
        <ul>
            <li>This value is not a valid email address.</li>
        </ul>
    </div>
    <hr class="mt-3">
    <input type="submit" id="w1-submit" class="button is-block is-info is-fullwidth" name="w1-submit" value="Save">
</form>
```