### PR TITLE
Add `defaultTokens()`.

### DIFF
--- a/src/Widget/Attribute/FieldAttributes.php
+++ b/src/Widget/Attribute/FieldAttributes.php
@@ -48,6 +48,20 @@ abstract class FieldAttributes extends WidgetAttributes
     }
 
     /**
+     * Set aria-label attribute.
+     *
+     * @param string $value
+     *
+     * @return static
+     */
+    public function ariaLabel(string $value): self
+    {
+        $new = clone $this;
+        $new->attributes['aria-label'] = $value;
+        return $new;
+    }
+
+    /**
      * Enable, disabled container for field.
      *
      * @param bool $value Is the container disabled or not.

--- a/src/Widget/Attribute/FieldAttributes.php
+++ b/src/Widget/Attribute/FieldAttributes.php
@@ -585,10 +585,9 @@ abstract class FieldAttributes extends WidgetAttributes
     }
 
     /**
-     * Return default tokens for field.
+     * Return default tokens.
      *
-     * if default tokens is empty array, and default tokens default value is not empty array, then return default tokens
-     * default value.
+     * The value is used in case tokens array is empty.
      */
     protected function getDefaultTokens(): array
     {

--- a/src/Widget/Attribute/FieldAttributes.php
+++ b/src/Widget/Attribute/FieldAttributes.php
@@ -10,6 +10,7 @@ abstract class FieldAttributes extends WidgetAttributes
     private ?bool $container = null;
     private array $containerAttributes = [];
     private string $containerClass = '';
+    private array $defaultTokens = [];
     private array $defaultValues = [];
     private ?string $error = '';
     private array $errorAttributes = [];
@@ -117,6 +118,20 @@ abstract class FieldAttributes extends WidgetAttributes
     {
         $new = clone $this;
         $new->containerAttributes['name'] = $id;
+        return $new;
+    }
+
+    /**
+     * Set default tokens.
+     *
+     * @param array $values Token values indexed by token names.
+     *
+     * @return static
+     */
+    public function defaultTokens(array $values): self
+    {
+        $new = clone $this;
+        $new->defaultTokens = $values;
         return $new;
     }
 
@@ -553,6 +568,14 @@ abstract class FieldAttributes extends WidgetAttributes
         }
 
         return $containerClass;
+    }
+
+    /**
+     * Return default tokens for field.
+     */
+    protected function getDefaultTokens(): array
+    {
+        return $this->defaultTokens;
     }
 
     /**

--- a/src/Widget/Attribute/FieldAttributes.php
+++ b/src/Widget/Attribute/FieldAttributes.php
@@ -586,10 +586,20 @@ abstract class FieldAttributes extends WidgetAttributes
 
     /**
      * Return default tokens for field.
+     *
+     * if default tokens is empty array, and default tokens default value is not empty array, then return default tokens
+     * default value.
      */
     protected function getDefaultTokens(): array
     {
-        return $this->defaultTokens;
+        $defaultTokens = $this->defaultTokens;
+        $defaultTokensDefault = $this->getDefaultValue($this->type, 'defaultTokens');
+
+        if (is_array($defaultTokensDefault) && $defaultTokensDefault !== []) {
+            $defaultTokens = $defaultTokensDefault;
+        }
+
+        return $defaultTokens;
     }
 
     /**

--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -717,7 +717,7 @@ final class Field extends FieldAttributes
         }
 
         if ($new->getDefaultTokens() !== []) {
-            $new->parts = array_merge($new->getDefaultTokens(), $new->parts);
+            $new->parts = array_merge($new->parts, $new->getDefaultTokens());
         }
 
         return preg_replace('/^\h*\v+/m', '', trim(strtr($new->getTemplate(), $new->parts)));

--- a/src/Widget/Field.php
+++ b/src/Widget/Field.php
@@ -716,6 +716,10 @@ final class Field extends FieldAttributes
             $new->parts['{label}'] = $new->renderLabel();
         }
 
+        if ($new->getDefaultTokens() !== []) {
+            $new->parts = array_merge($new->getDefaultTokens(), $new->parts);
+        }
+
         return preg_replace('/^\h*\v+/m', '', trim(strtr($new->getTemplate(), $new->parts)));
     }
 

--- a/tests/Widget/Field/FieldTest.php
+++ b/tests/Widget/Field/FieldTest.php
@@ -86,6 +86,62 @@ final class FieldTest extends TestCase
     }
 
     /**
+     * @link https://getbootstrap.com/docs/5.0/forms/input-group/
+     *
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
+    public function testDefaultTokensWithDefaultValues(): void
+    {
+        $factoryConfig = [
+            'defaultValues()' => [
+                [
+                    'text' => [
+                        'defaultTokens' => [
+                            '{after}' => Span::tag()->class('input-group-text')->content('$'),
+                            '{before}' => Span::tag()->class('input-group-text')->content('.00'),
+                        ],
+                        'template' => "{before}\n{input}\n{after}\n{error}",
+                    ],
+                    'textArea' => [
+                        'defaultTokens' => [
+                            '{before}' => Span::tag()->class('input-group-text')->content('With textarea'),
+                        ],
+                        'template' => "{before}\n{input}\n{error}",
+                    ],
+                ],
+            ],
+        ];
+
+        $field = Field::widget($factoryConfig);
+
+        $expected = <<<HTML
+        <div class="input-group mb-3">
+        <span class="input-group-text">.00</span>
+        <input type="text" id="typeform-string" class="form-control" name="TypeForm[string]" aria-describedby="typeform-string-help" aria-label="Amount (to the nearest dollar)">
+        <span class="input-group-text">$</span>
+        </div>
+        <div class="input-group">
+        <span class="input-group-text">With textarea</span>
+        <textarea id="typeform-string" name="TypeForm[string]"></textarea>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            $field
+                ->ariaDescribedBy(true)
+                ->ariaLabel('Amount (to the nearest dollar)')
+                ->containerClass('input-group mb-3')
+                ->inputClass('form-control')
+                ->text(new TypeForm(), 'string')
+                ->render() . PHP_EOL .
+            $field
+                ->containerClass('input-group')
+                ->textArea(new TypeForm(), 'string')
+                ->render(),
+        );
+    }
+
+    /**
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
      */
     public function testLabelFor(): void

--- a/tests/Widget/Field/FieldTest.php
+++ b/tests/Widget/Field/FieldTest.php
@@ -9,9 +9,10 @@ use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
 use Yiisoft\Factory\NotFoundException;
-use Yiisoft\Form\Tests\TestSupport\TestTrait;
 use Yiisoft\Form\Tests\TestSupport\Form\TypeForm;
+use Yiisoft\Form\Tests\TestSupport\TestTrait;
 use Yiisoft\Form\Widget\Field;
+use Yiisoft\Html\Tag\Span;
 
 final class FieldTest extends TestCase
 {
@@ -48,6 +49,39 @@ final class FieldTest extends TestCase
         $this->assertEqualsWithoutLE(
             $expected,
             Field::widget()->containerName('name-test')->text(new TypeForm(), 'string')->render(),
+        );
+    }
+
+    /**
+     * @link https://getbootstrap.com/docs/5.0/forms/input-group/
+     *
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
+    public function testDefaultTokens(): void
+    {
+        $expected = <<<HTML
+        <div class="input-group mb-3">
+        <span class="input-group-text">.00</span>
+        <input type="text" id="typeform-string" class="form-control" name="TypeForm[string]" aria-describedby="typeform-string-help" aria-label="Amount (to the nearest dollar)">
+        <span class="input-group-text">$</span>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()
+                ->ariaDescribedBy(true)
+                ->ariaLabel("Amount (to the nearest dollar)")
+                ->containerClass('input-group mb-3')
+                ->defaultTokens(
+                    [
+                        '{after}' => Span::tag()->class('input-group-text')->content('$'),
+                        '{before}' => Span::tag()->class('input-group-text')->content('.00'),
+                    ]
+                )
+                ->inputClass('form-control')
+                ->template("{before}\n{input}\n{after}\n{hint}\n{error}")
+                ->text(new TypeForm(), 'string')
+                ->render(),
         );
     }
 

--- a/tests/Widget/Field/FieldTest.php
+++ b/tests/Widget/Field/FieldTest.php
@@ -70,7 +70,7 @@ final class FieldTest extends TestCase
             $expected,
             Field::widget()
                 ->ariaDescribedBy(true)
-                ->ariaLabel("Amount (to the nearest dollar)")
+                ->ariaLabel('Amount (to the nearest dollar)')
                 ->containerClass('input-group mb-3')
                 ->defaultTokens(
                     [

--- a/tests/Widget/Field/FieldTest.php
+++ b/tests/Widget/Field/FieldTest.php
@@ -13,6 +13,7 @@ use Yiisoft\Form\Tests\TestSupport\Form\TypeForm;
 use Yiisoft\Form\Tests\TestSupport\TestTrait;
 use Yiisoft\Form\Widget\Field;
 use Yiisoft\Html\Tag\Span;
+use Yiisoft\Html\Tag\Input;
 
 final class FieldTest extends TestCase
 {
@@ -80,6 +81,31 @@ final class FieldTest extends TestCase
                 )
                 ->inputClass('form-control')
                 ->template("{before}\n{input}\n{after}\n{hint}\n{error}")
+                ->text(new TypeForm(), 'string')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
+    public function testDefaultTokensWithOverrideToken(): void
+    {
+        $expected = <<<HTML
+        <div>
+        <label for="typeform-string">String</label>
+        <input type="color" id="typeform-string" name="TypeForm[string]">
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()
+                ->defaultTokens(
+                    [
+                        '{input}' => Input::tag()->id('typeform-string')->name('TypeForm[string]')->type('color'),
+                    ]
+                )
+                ->template("{label}\n{input}\n{hint}\n{error}")
                 ->text(new TypeForm(), 'string')
                 ->render(),
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Add the ability to add tokens, to be used by the general template, or template per widget. 

https://getbootstrap.com/docs/5.0/forms/input-group/

Example general:

```php
$expected = <<<HTML
<div class="input-group mb-3">
<span class="input-group-text">.00</span>
<input type="text" id="typeform-string" class="form-control" name="TypeForm[string]" aria-describedby="typeform-string-help" aria-label="Amount (to the nearest dollar)">
<span class="input-group-text">$</span>
</div>
HTML;
$this->assertEqualsWithoutLE(
    $expected,
    Field::widget()
        ->ariaDescribedBy(true)
        ->ariaLabel('Amount (to the nearest dollar)')
        ->containerClass('input-group mb-3')
        ->defaultTokens(
            [
                '{after}' => Span::tag()->class('input-group-text')->content('$'),
                '{before}' => Span::tag()->class('input-group-text')->content('.00'),
            ]
        )
        ->inputClass('form-control')
        ->template("{before}\n{input}\n{after}\n{hint}\n{error}")
        ->text(new TypeForm(), 'string')
        ->render(),
);
```

Example for widget:
```php
$factoryConfig = [
    'defaultValues()' => [
        [
            'text' => [
                'defaultTokens' => [
                    '{after}' => Span::tag()->class('input-group-text')->content('$'),
                    '{before}' => Span::tag()->class('input-group-text')->content('.00'),
                ],
                'template' => "{before}\n{input}\n{after}\n{error}",
            ],
            'textArea' => [
                'defaultTokens' => [
                    '{before}' => Span::tag()->class('input-group-text')->content('With textarea'),
                ],
                'template' => "{before}\n{input}\n{error}",
            ],
        ],
    ],
];

$field = Field::widget($factoryConfig);

$expected = <<<HTML
<div class="input-group mb-3">
<span class="input-group-text">.00</span>
<input type="text" id="typeform-string" class="form-control" name="TypeForm[string]" aria-describedby="typeform-string-help" aria-label="Amount (to the nearest dollar)">
<span class="input-group-text">$</span>
</div>
<div class="input-group">
<span class="input-group-text">With textarea</span>
<textarea id="typeform-string" name="TypeForm[string]"></textarea>
</div>
HTML;
$this->assertEqualsWithoutLE(
    $expected,
    $field
        ->ariaDescribedBy(true)
        ->ariaLabel('Amount (to the nearest dollar)')
        ->containerClass('input-group mb-3')
        ->inputClass('form-control')
        ->text(new TypeForm(), 'string')
        ->render() . PHP_EOL .
    $field
        ->containerClass('input-group')
        ->textArea(new TypeForm(), 'string')
        ->render(),
);
```

Example overriden token:
```php
$expected = <<<HTML
<div>
<label for="typeform-string">String</label>
<input type="color" id="typeform-string" name="TypeForm[string]">
</div>
HTML;
$this->assertEqualsWithoutLE(
    $expected,
    Field::widget()
        ->defaultTokens(
            [
                '{input}' => Input::tag()->id('typeform-string')->name('TypeForm[string]')->type('color'),
            ]
        )
        ->template("{label}\n{input}\n{hint}\n{error}")
        ->text(new TypeForm(), 'string')
        ->render(),
);
```
