### PR TITLE
Add `replaceIndividualToken()` method.

### DIFF
--- a/src/Widget/Attribute/FieldAttributes.php
+++ b/src/Widget/Attribute/FieldAttributes.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Yiisoft\Form\Widget\Attribute;
 
+use InvalidArgumentException;
+use Stringable;
+
 abstract class FieldAttributes extends WidgetAttributes
 {
     private ?bool $ariaDescribedBy = null;
@@ -419,6 +422,27 @@ abstract class FieldAttributes extends WidgetAttributes
     {
         $new = clone $this;
         $new->attributes['readonly'] = $value;
+        return $new;
+    }
+
+    /**
+     * Replace individual one token for current field instance.
+     *
+     * @param string $token
+     * @param string|Stringable $value
+     *
+     * @return static
+     */
+    public function replaceIndividualToken(string $token, $value): self
+    {
+        $new = clone $this;
+
+        if (is_string($value) || (is_object($value) && method_exists($value, '__toString'))) {
+            $new->defaultTokens[$token] = (string) $value;
+        } else {
+            throw new InvalidArgumentException('$token must be a string or \Stringable object.');
+        }
+
         return $new;
     }
 

--- a/src/Widget/Attribute/FieldAttributes.php
+++ b/src/Widget/Attribute/FieldAttributes.php
@@ -429,7 +429,7 @@ abstract class FieldAttributes extends WidgetAttributes
      * Replace individual one token for current field instance.
      *
      * @param string $token
-     * @param string|Stringable $value
+     * @param mixed|string|Stringable $value
      *
      * @return static
      */

--- a/tests/Widget/Field/FieldTest.php
+++ b/tests/Widget/Field/FieldTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Form\Tests\Widget\Field;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
@@ -12,8 +13,8 @@ use Yiisoft\Factory\NotFoundException;
 use Yiisoft\Form\Tests\TestSupport\Form\TypeForm;
 use Yiisoft\Form\Tests\TestSupport\TestTrait;
 use Yiisoft\Form\Widget\Field;
-use Yiisoft\Html\Tag\Span;
 use Yiisoft\Html\Tag\Input;
+use Yiisoft\Html\Tag\Span;
 
 final class FieldTest extends TestCase
 {
@@ -182,5 +183,50 @@ final class FieldTest extends TestCase
             $expected,
             Field::widget()->labelFor('id-test')->text(new TypeForm(), 'string')->render(),
         );
+    }
+
+    /**
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
+    public function testReplaceIndividualToken(): void
+    {
+        $factoryConfig = [
+            'defaultTokens()' => [
+                [
+                    '{after}' => Span::tag()->class('input-group-text')->content('$'),
+                    '{before}' => Span::tag()->class('input-group-text')->content('.00'),
+                ],
+            ],
+        ];
+
+        $expected = <<<HTML
+        <div class="input-group mb-3">
+        <span class="input-group-text">.00</span>
+        <input type="text" id="typeform-string" class="form-control" name="TypeForm[string]" aria-describedby="typeform-string-help" aria-label="Amount (to the nearest dollar)">
+        <span class="input-group-text">€</span>
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget($factoryConfig)
+                ->ariaDescribedBy(true)
+                ->ariaLabel('Amount (to the nearest dollar)')
+                ->containerClass('input-group mb-3')
+                ->inputClass('form-control')
+                ->replaceIndividualToken('{after}', Span::tag()->class('input-group-text')->content('€'))
+                ->template("{before}\n{input}\n{after}\n{hint}\n{error}")
+                ->text(new TypeForm(), 'string')
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
+    public function testReplaceIndividualTokenException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$token must be a string or \Stringable object.');
+        Field::widget()->replaceIndividualToken('{after}', 1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Added the ability to dynamically replace a token for custom widget.

```php
$factoryConfig = [
    'defaultTokens()' => [
        [
            '{after}' => Span::tag()->class('input-group-text')->content('$'),
            '{before}' => Span::tag()->class('input-group-text')->content('.00'),
        ],
    ],
];

$expected = <<<HTML
<div class="input-group mb-3">
<span class="input-group-text">.00</span>
<input type="text" id="typeform-string" class="form-control" name="TypeForm[string]" aria-describedby="typeform-string-help" aria-label="Amount (to the nearest dollar)">
<span class="input-group-text">€</span>
</div>
HTML;
$this->assertEqualsWithoutLE(
    $expected,
    Field::widget($factoryConfig)
        ->ariaDescribedBy(true)
        ->ariaLabel('Amount (to the nearest dollar)')
        ->containerClass('input-group mb-3')
        ->inputClass('form-control')
        ->replaceIndividualToken('{after}', Span::tag()->class('input-group-text')->content('€'))
        ->template("{before}\n{input}\n{after}\n{hint}\n{error}")
        ->text(new TypeForm(), 'string')
        ->render(),
);
```