### PR TITLE
Remove cast before validation.

### DIFF
--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -116,6 +116,8 @@ interface FormModelInterface extends DataSetInterface, FormMetadataInterface
      * @param string|null $formName scope from which to get data
      *
      * @return bool whether `load()` found the expected form in `$data`.
+     *
+     * @psalm-param array<string, string> $data
      */
     public function load(array $data, ?string $formName = null): bool;
 

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -214,10 +214,18 @@ final class FormModelTest extends TestCase
             'bool' => 'false',
             'string' => 555,
         ], '');
-        $this->assertIsInt($form->getAttributeValue('int'));
-        $this->assertIsFloat($form->getAttributeValue('float'));
-        $this->assertIsBool($form->getAttributeValue('bool'));
-        $this->assertIsString($form->getAttributeValue('string'));
+
+        // check row data value.
+        $this->assertIsString($form->getAttributeValue('int'));
+        $this->assertIsString($form->getAttributeValue('float'));
+        $this->assertIsString($form->getAttributeValue('bool'));
+        $this->assertIsInt($form->getAttributeValue('string'));
+
+        // chech cast data value.
+        $this->assertIsInt($form->getAttributeCastValue('int'));
+        $this->assertIsFloat($form->getAttributeCastValue('float'));
+        $this->assertIsBool($form->getAttributeCastValue('bool'));
+        $this->assertIsString($form->getAttributeCastValue('string'));
     }
 
     public function testLoadWithNestedAttribute(): void
@@ -245,11 +253,14 @@ final class FormModelTest extends TestCase
         $form = new class () extends FormModel {
             public int $int = 1;
         };
-        $form->load(['int' => '2']);
-        $this->assertSame(2, $form->getAttributeValue('int'));
 
+        // check row data value.
+        $form->load(['int' => '2']);
+        $this->assertSame('2', $form->getAttributeValue('int'));
+
+        // chech cast data value.
         $form->setAttribute('int', 1);
-        $this->assertSame(1, $form->getAttributeValue('int'));
+        $this->assertSame(1, $form->getAttributeCastValue('int'));
     }
 
     public function testAttributeNames(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Now `getAttributeValue()` returns the raw data if it is loaded by the load method, which allows validating the data in its raw state.

https://github.com/yiisoft/validator/blob/d8d7b602d44f21f6fac1fda4164771238881bc10/src/Validator.php#L48