### PR TITLE
Allow null, numeric or string  `hidden::class` widget.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ phpunit.phar
 /phpunit.xml
 # phpunit cache
 .phpunit.result.cache
-/html

--- a/src/Widget/Hidden.php
+++ b/src/Widget/Hidden.php
@@ -34,7 +34,7 @@ final class Hidden extends InputAttributes
         }
 
         if (!array_key_exists('name', $attributes)) {
-            $attributes['name'] = $this->getInputId();
+            $attributes['name'] = $this->getInputName();
         }
 
         return Input::tag()->type('hidden')->attributes($attributes)->value($value === '' ? null : $value)->render();

--- a/src/Widget/Hidden.php
+++ b/src/Widget/Hidden.php
@@ -29,7 +29,7 @@ final class Hidden extends InputAttributes
         $value = $attributes['value'] ?? $this->getAttributeValue();
         unset($attributes['value']);
 
-        if (!is_string($value)) {
+        if (!is_string($value) && !is_numeric($value) && !is_null($value)) {
             throw new InvalidArgumentException('Hidden widget requires a string value.');
         }
 

--- a/src/Widget/Hidden.php
+++ b/src/Widget/Hidden.php
@@ -29,7 +29,7 @@ final class Hidden extends InputAttributes
         $value = $attributes['value'] ?? $this->getAttributeValue();
         unset($attributes['value']);
 
-        if (!is_string($value) && !is_numeric($value) && !is_null($value)) {
+        if (!is_string($value) && !is_numeric($value) && null !== $value) {
             throw new InvalidArgumentException('Hidden widget requires a string, numeric or null value.');
         }
 

--- a/src/Widget/Hidden.php
+++ b/src/Widget/Hidden.php
@@ -29,13 +29,8 @@ final class Hidden extends InputAttributes
         $value = $attributes['value'] ?? $this->getAttributeValue();
         unset($attributes['value']);
 
-<<<<<<< HEAD
         if (!is_string($value) && !is_numeric($value) && !is_null($value)) {
             throw new InvalidArgumentException('Hidden widget requires a string, numeric or null value.');
-=======
-        if (!is_string($value) && !is_numeric($value) && null !== $value) {
-            throw new InvalidArgumentException('Hidden widget requires a string value.');
->>>>>>> 46a5b82f580d84b7c0f2725294a936bf67aedf39
         }
 
         if (!array_key_exists('name', $attributes)) {

--- a/src/Widget/Hidden.php
+++ b/src/Widget/Hidden.php
@@ -30,7 +30,7 @@ final class Hidden extends InputAttributes
         unset($attributes['value']);
 
         if (!is_string($value) && !is_numeric($value) && !is_null($value)) {
-            throw new InvalidArgumentException('Hidden widget requires a string value.');
+            throw new InvalidArgumentException('Hidden widget requires a string, numeric or null value.');
         }
 
         if (!array_key_exists('name', $attributes)) {

--- a/tests/Widget/Field/FieldHiddenTest.php
+++ b/tests/Widget/Field/FieldHiddenTest.php
@@ -21,11 +21,27 @@ final class FieldHiddenTest extends TestCase
     /**
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
      */
+    public function testName(): void
+    {
+        $expected = <<<HTML
+        <div>
+        <input type="hidden" name="ActiveField[form_action]">
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()->name('ActiveField[form_action]')->hidden(new TypeForm(), 'string')->render(),
+        );
+    }
+
+    /**
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
     public function testRender(): void
     {
         $expected = <<<HTML
         <div>
-        <input type="hidden" name="typeform-string">
+        <input type="hidden" name="TypeForm[string]">
         </div>
         HTML;
         $this->assertEqualsWithoutLE(
@@ -41,7 +57,7 @@ final class FieldHiddenTest extends TestCase
     {
         $expected = <<<HTML
         <div>
-        <input type="hidden" name="typeform-string" value="1">
+        <input type="hidden" name="TypeForm[string]" value="1">
         </div>
         HTML;
         // Value string `1`.
@@ -52,7 +68,7 @@ final class FieldHiddenTest extends TestCase
 
         $expected = <<<HTML
         <div>
-        <input type="hidden" name="typeform-int" value="1">
+        <input type="hidden" name="TypeForm[int]" value="1">
         </div>
         HTML;
         // Value integer 1.
@@ -63,7 +79,7 @@ final class FieldHiddenTest extends TestCase
 
         $expected = <<<HTML
         <div>
-        <input type="hidden" name="typeform-string">
+        <input type="hidden" name="TypeForm[string]">
         </div>
         HTML;
         // Value null.
@@ -94,7 +110,7 @@ final class FieldHiddenTest extends TestCase
         $formModel->setAttribute('string', '1');
         $expected = <<<HTML
         <div>
-        <input type="hidden" name="typeform-string" value="1">
+        <input type="hidden" name="TypeForm[string]" value="1">
         </div>
         HTML;
         $this->assertEqualsWithoutLE(
@@ -106,7 +122,7 @@ final class FieldHiddenTest extends TestCase
         $formModel->setAttribute('int', 1);
         $expected = <<<HTML
         <div>
-        <input type="hidden" name="typeform-int" value="1">
+        <input type="hidden" name="TypeForm[int]" value="1">
         </div>
         HTML;
         $this->assertEqualsWithoutLE(
@@ -118,7 +134,7 @@ final class FieldHiddenTest extends TestCase
         $formModel->setAttribute('string', null);
         $expected = <<<HTML
         <div>
-        <input type="hidden" name="typeform-string">
+        <input type="hidden" name="TypeForm[string]">
         </div>
         HTML;
         $this->assertEqualsWithoutLE(

--- a/tests/Widget/Field/FieldHiddenTest.php
+++ b/tests/Widget/Field/FieldHiddenTest.php
@@ -23,7 +23,7 @@ final class FieldHiddenTest extends TestCase
      */
     public function testRender(): void
     {
-        $expected = <<<'HTML'
+        $expected = <<<HTML
         <div>
         <input type="hidden" name="typeform-string">
         </div>
@@ -39,7 +39,7 @@ final class FieldHiddenTest extends TestCase
      */
     public function testValue(): void
     {
-        $expected = <<<'HTML'
+        $expected = <<<HTML
         <div>
         <input type="hidden" name="typeform-string" value="1">
         </div>
@@ -50,7 +50,7 @@ final class FieldHiddenTest extends TestCase
             Field::widget()->hidden(new TypeForm(), 'string')->value('1')->render(),
         );
 
-        $expected = <<<'HTML'
+        $expected = <<<HTML
         <div>
         <input type="hidden" name="typeform-int" value="1">
         </div>
@@ -61,7 +61,7 @@ final class FieldHiddenTest extends TestCase
             Field::widget()->hidden(new TypeForm(), 'int')->value(1)->render(),
         );
 
-        $expected = <<<'HTML'
+        $expected = <<<HTML
         <div>
         <input type="hidden" name="typeform-string">
         </div>
@@ -92,7 +92,7 @@ final class FieldHiddenTest extends TestCase
 
         // Value string `1`.
         $formModel->setAttribute('string', '1');
-        $expected = <<<'HTML'
+        $expected = <<<HTML
         <div>
         <input type="hidden" name="typeform-string" value="1">
         </div>
@@ -104,7 +104,7 @@ final class FieldHiddenTest extends TestCase
 
         // Value integer 1.
         $formModel->setAttribute('int', 1);
-        $expected = <<<'HTML'
+        $expected = <<<HTML
         <div>
         <input type="hidden" name="typeform-int" value="1">
         </div>
@@ -116,7 +116,7 @@ final class FieldHiddenTest extends TestCase
 
         // Value `null`.
         $formModel->setAttribute('string', null);
-        $expected = <<<'HTML'
+        $expected = <<<HTML
         <div>
         <input type="hidden" name="typeform-string">
         </div>

--- a/tests/Widget/Field/FieldHiddenTest.php
+++ b/tests/Widget/Field/FieldHiddenTest.php
@@ -37,10 +37,93 @@ final class FieldHiddenTest extends TestCase
     /**
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
      */
+    public function testValue(): void
+    {
+        $expected = <<<'HTML'
+        <div>
+        <input type="hidden" name="typeform-string" value="1">
+        </div>
+        HTML;
+        // Value string `1`.
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()->hidden(new TypeForm(), 'string')->value('1')->render(),
+        );
+
+        $expected = <<<'HTML'
+        <div>
+        <input type="hidden" name="typeform-int" value="1">
+        </div>
+        HTML;
+        // Value integer 1.
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()->hidden(new TypeForm(), 'int')->value(1)->render(),
+        );
+
+        $expected = <<<'HTML'
+        <div>
+        <input type="hidden" name="typeform-string">
+        </div>
+        HTML;
+        // Value null.
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()->hidden(new TypeForm(), 'string')->value(null)->render(),
+        );
+    }
+
+    /**
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
     public function testValueException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Hidden widget requires a string value.');
+        $this->expectExceptionMessage('Hidden widget requires a string, numeric or null value.');
         Field::widget()->hidden(new TypeForm(), 'array')->render();
+    }
+
+    /**
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
+    public function testValueWithFormModel(): void
+    {
+        $formModel = new TypeForm();
+
+        // Value string `1`.
+        $formModel->setAttribute('string', '1');
+        $expected = <<<'HTML'
+        <div>
+        <input type="hidden" name="typeform-string" value="1">
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()->hidden($formModel, 'string')->render(),
+        );
+
+        // Value integer 1.
+        $formModel->setAttribute('int', 1);
+        $expected = <<<'HTML'
+        <div>
+        <input type="hidden" name="typeform-int" value="1">
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()->hidden($formModel, 'int')->render(),
+        );
+
+        // Value `null`.
+        $formModel->setAttribute('string', null);
+        $expected = <<<'HTML'
+        <div>
+        <input type="hidden" name="typeform-string">
+        </div>
+        HTML;
+        $this->assertEqualsWithoutLE(
+            $expected,
+            Field::widget()->hidden($formModel, 'string')->render(),
+        );
     }
 }

--- a/tests/Widget/HiddenTest.php
+++ b/tests/Widget/HiddenTest.php
@@ -32,10 +32,63 @@ final class HiddenTest extends TestCase
     /**
      * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
      */
+    public function testValue(): void
+    {
+        // Value string `1`.
+        $this->assertSame(
+            '<input type="hidden" name="typeform-string" value="1">',
+            Hidden::widget()->for(new TypeForm(), 'string')->value('1')->render(),
+        );
+
+        // Value integer 1.
+        $this->assertSame(
+            '<input type="hidden" name="typeform-string" value="1">',
+            Hidden::widget()->for(new TypeForm(), 'string')->value(1)->render(),
+        );
+
+        // Value null.
+        $this->assertSame(
+            '<input type="hidden" name="typeform-string">',
+            Hidden::widget()->for(new TypeForm(), 'string')->value(null)->render(),
+        );
+    }
+
+    /**
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
     public function testValueException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Hidden widget requires a string value.');
         Hidden::widget()->for(new TypeForm(), 'array')->render();
+    }
+
+    /**
+     * @throws CircularReferenceException|InvalidConfigException|NotFoundException|NotInstantiableException
+     */
+    public function testValueWithForm(): void
+    {
+        $formModel = new TypeForm();
+
+        // Value string `1`.
+        $formModel->setAttribute('string', '1');
+        $this->assertSame(
+            '<input type="hidden" name="typeform-string" value="1">',
+            Hidden::widget()->for($formModel, 'string')->render(),
+        );
+
+        // Value integer 1.
+        $formModel->setAttribute('int', 1);
+        $this->assertSame(
+            '<input type="hidden" name="typeform-int" value="1">',
+            Hidden::widget()->for($formModel, 'int')->render(),
+        );
+
+        // Value `null`.
+        $formModel->setAttribute('string', null);
+        $this->assertSame(
+            '<input type="hidden" name="typeform-string">',
+            Hidden::widget()->for($formModel, 'string')->render(),
+        );
     }
 }

--- a/tests/Widget/HiddenTest.php
+++ b/tests/Widget/HiddenTest.php
@@ -59,7 +59,7 @@ final class HiddenTest extends TestCase
     public function testValueException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Hidden widget requires a string value.');
+        $this->expectExceptionMessage('Hidden widget requires a string, numeric or null value.');
         Hidden::widget()->for(new TypeForm(), 'array')->render();
     }
 

--- a/tests/Widget/HiddenTest.php
+++ b/tests/Widget/HiddenTest.php
@@ -24,7 +24,7 @@ final class HiddenTest extends TestCase
     public function testRender(): void
     {
         $this->assertSame(
-            '<input type="hidden" name="typeform-string">',
+            '<input type="hidden" name="TypeForm[string]">',
             Hidden::widget()->for(new TypeForm(), 'string')->render(),
         );
     }
@@ -36,19 +36,19 @@ final class HiddenTest extends TestCase
     {
         // Value string `1`.
         $this->assertSame(
-            '<input type="hidden" name="typeform-string" value="1">',
+            '<input type="hidden" name="TypeForm[string]" value="1">',
             Hidden::widget()->for(new TypeForm(), 'string')->value('1')->render(),
         );
 
         // Value integer 1.
         $this->assertSame(
-            '<input type="hidden" name="typeform-string" value="1">',
-            Hidden::widget()->for(new TypeForm(), 'string')->value(1)->render(),
+            '<input type="hidden" name="TypeForm[int]" value="1">',
+            Hidden::widget()->for(new TypeForm(), 'int')->value(1)->render(),
         );
 
         // Value null.
         $this->assertSame(
-            '<input type="hidden" name="typeform-string">',
+            '<input type="hidden" name="TypeForm[string]">',
             Hidden::widget()->for(new TypeForm(), 'string')->value(null)->render(),
         );
     }
@@ -73,21 +73,21 @@ final class HiddenTest extends TestCase
         // Value string `1`.
         $formModel->setAttribute('string', '1');
         $this->assertSame(
-            '<input type="hidden" name="typeform-string" value="1">',
+            '<input type="hidden" name="TypeForm[string]" value="1">',
             Hidden::widget()->for($formModel, 'string')->render(),
         );
 
         // Value integer 1.
         $formModel->setAttribute('int', 1);
         $this->assertSame(
-            '<input type="hidden" name="typeform-int" value="1">',
+            '<input type="hidden" name="TypeForm[int]" value="1">',
             Hidden::widget()->for($formModel, 'int')->render(),
         );
 
         // Value `null`.
         $formModel->setAttribute('string', null);
         $this->assertSame(
-            '<input type="hidden" name="typeform-string">',
+            '<input type="hidden" name="TypeForm[string]">',
             Hidden::widget()->for($formModel, 'string')->render(),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
