### PR TITLE
Allow symbols in input name

### DIFF
--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -20,6 +20,15 @@ interface FormModelInterface extends DataSetInterface, FormMetadataInterface
     public function attributes(): array;
 
     /**
+     * Check for attribute exists in model
+     *
+     * @param string $attribute
+     *
+     * @return bool
+     */
+    public function hasAttribute(string $attribute): bool;
+
+    /**
      * Returns the value for the specified attribute.
      *
      * @param string $attribute

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -20,15 +20,6 @@ interface FormModelInterface extends DataSetInterface, FormMetadataInterface
     public function attributes(): array;
 
     /**
-     * Check for attribute exists in model
-     *
-     * @param string $attribute
-     *
-     * @return bool
-     */
-    public function hasAttribute(string $attribute): bool;
-
-    /**
      * Returns the value for the specified attribute.
      *
      * @param string $attribute

--- a/src/Helper/HtmlForm.php
+++ b/src/Helper/HtmlForm.php
@@ -184,7 +184,7 @@ final class HtmlForm
      */
     private static function parseAttribute(string $attribute): array
     {
-        if (!preg_match('/(^|.*\])([\w\.\+]+)(\[.*|$)/u', $attribute, $matches)) {
+        if (!preg_match('/(^|.*\])([\w\.\+\-_]+)(\[.*|$)/u', $attribute, $matches)) {
             throw new InvalidArgumentException('Attribute name must contain word characters only.');
         }
         return [

--- a/tests/Helper/HtmlFormTest.php
+++ b/tests/Helper/HtmlFormTest.php
@@ -13,16 +13,22 @@ use Yiisoft\Form\Tests\TestSupport\Form\DynamicFieldsForm;
 
 final class HtmlFormTest extends TestCase
 {
-    public function dynamicFieldsProvider(string $formName): array
+    public function dynamicFieldsProvider(): array
     {
         return [
-            '7aeceb9b-fa64-4a83-ae6a-5f602772c01b' => [
-                'value' => 'some uuid value',
-                'expected' => $formName . '[7aeceb9b-fa64-4a83-ae6a-5f602772c01b]',
-            ],
-            'test_field' => [
-                'value' => 'some test value',
-                'expected' => $formName . '[test_field]',
+            [
+                [
+                    [
+                        'name' => '7aeceb9b-fa64-4a83-ae6a-5f602772c01b',
+                        'value' => 'some uuid value',
+                        'expected' => 'DynamicFieldsForm[7aeceb9b-fa64-4a83-ae6a-5f602772c01b]',
+                    ],
+                    [
+                        'name' => 'test_field',
+                        'value' => 'some test value',
+                        'expected' => 'DynamicFieldsForm[test_field]',
+                    ],
+                ],
             ],
         ];
     }
@@ -97,20 +103,22 @@ final class HtmlFormTest extends TestCase
         HtmlForm::getInputName($anonymousForm, '[0]dates[0]');
     }
 
-    public function testUUIDInputName(): void
+    /**
+     * @dataProvider dynamicFieldsProvider
+     */
+    public function testUUIDInputName(array $fields): void
     {
-        $fields = $this->dynamicFieldsProvider('DynamicFieldsForm');
-        $keys = array_keys($fields);
+        $keys = array_column($fields, 'name');
         $form = new DynamicFieldsForm(array_fill_keys($keys, null));
 
-        foreach ($fields as $name => $field) {
-            $inputName = HtmlForm::getInputName($form, $name);
+        foreach ($fields as $field) {
+            $inputName = HtmlForm::getInputName($form, $field['name']);
             $this->assertSame($field['expected'], $inputName);
-            $this->assertTrue($form->hasAttribute($name));
-            $this->assertNull($form->getAttributeValue($name));
+            $this->assertTrue($form->hasAttribute($field['name']));
+            $this->assertNull($form->getAttributeValue($field['name']));
 
-            $form->setAttribute($name, $field['value']);
-            $this->assertSame($field['value'], $form->getAttributeValue($name));
+            $form->setAttribute($field['name'], $field['value']);
+            $this->assertSame($field['value'], $form->getAttributeValue($field['name']));
         }
     }
 }

--- a/tests/Helper/HtmlFormTest.php
+++ b/tests/Helper/HtmlFormTest.php
@@ -13,6 +13,20 @@ use Yiisoft\Form\Tests\TestSupport\Form\DynamicFieldsForm;
 
 final class HtmlFormTest extends TestCase
 {
+    public function dynamicFieldsProvider(string $formName): array
+    {
+        return [
+            '7aeceb9b-fa64-4a83-ae6a-5f602772c01b' => [
+                'value' => 'some uuid value',
+                'expected' => $formName . '[7aeceb9b-fa64-4a83-ae6a-5f602772c01b]',
+            ],
+            'test_field' => [
+                'value' => 'some test value',
+                'expected' => $formName . '[test_field]',
+            ],
+        ];
+    }
+
     public function testGetAttributeHint(): void
     {
         $formModel = new LoginForm();
@@ -85,16 +99,18 @@ final class HtmlFormTest extends TestCase
 
     public function testUUIDInputName(): void
     {
-        $fields = [
-            '7aeceb9b-fa64-4a83-ae6a-5f602772c01b' => null,
-            'test_field' => null,
-        ];
+        $fields = $this->dynamicFieldsProvider('DynamicFieldsForm');
+        $keys = array_keys($fields);
+        $form = new DynamicFieldsForm(array_fill_keys($keys, null));
 
-        $form = new DynamicFieldsForm($fields);
-
-        foreach ($fields as $name => $value) {
+        foreach ($fields as $name => $field) {
             $inputName = HtmlForm::getInputName($form, $name);
-            $this->assertSame('DynamicFieldsForm[' . $name . ']', $inputName);
+            $this->assertSame($field['expected'], $inputName);
+            $this->assertTrue($form->hasAttribute($name));
+            $this->assertNull($form->getAttributeValue($name));
+
+            $form->setAttribute($name, $field['value']);
+            $this->assertSame($field['value'], $form->getAttributeValue($name));
         }
     }
 }

--- a/tests/Helper/HtmlFormTest.php
+++ b/tests/Helper/HtmlFormTest.php
@@ -9,6 +9,7 @@ use Yiisoft\Form\FormModel;
 use Yiisoft\Form\FormModelInterface;
 use Yiisoft\Form\Helper\HtmlForm;
 use Yiisoft\Form\Tests\TestSupport\Form\LoginForm;
+use Yiisoft\Form\Tests\TestSupport\Form\DynamicFieldsForm;
 
 final class HtmlFormTest extends TestCase
 {
@@ -80,5 +81,20 @@ final class HtmlFormTest extends TestCase
 
         $this->expectExceptionMessage('formName() cannot be empty for tabular inputs.');
         HtmlForm::getInputName($anonymousForm, '[0]dates[0]');
+    }
+
+    public function testUUIDInputName(): void
+    {
+        $fields = [
+            '7aeceb9b-fa64-4a83-ae6a-5f602772c01b' => null,
+            'test_field' => null,
+        ];
+
+        $form = new DynamicFieldsForm($fields);
+
+        foreach ($fields as $name => $value) {
+            $inputName = HtmlForm::getInputName($form, $name);
+            $this->assertSame('DynamicFieldsForm[' . $name . ']', $inputName);
+        }
     }
 }

--- a/tests/TestSupport/Form/DynamicFieldsForm.php
+++ b/tests/TestSupport/Form/DynamicFieldsForm.php
@@ -20,28 +20,22 @@ final class DynamicFieldsForm extends FormModel
 
     public function hasAttribute(string $attribute): bool
     {
-        if (ArrayHelper::keyExists($this->fields, $attribute)) {
-            return true;
-        }
-
-        return parent::hasAttribute($attribute);
+        return ArrayHelper::keyExists($this->fields, $attribute);
     }
 
     public function getAttributeValue(string $attribute)
     {
-        if (ArrayHelper::keyExists($this->fields, $attribute)) {
+        if ($this->hasAttribute($attribute)) {
             return $this->fields[$attribute];
         }
 
-        return parent::getAttributeValue($attribute);
+        return null;
     }
 
     public function setAttribute(string $name, $value): void
     {
-        if (ArrayHelper::keyExists($this->fields, $name)) {
+        if ($this->hasAttribute($name)) {
             $this->fields[$name] = $value;
-        } else {
-            parent::setAttribute($name, $value);
         }
     }
 }

--- a/tests/TestSupport/Form/DynamicFieldsForm.php
+++ b/tests/TestSupport/Form/DynamicFieldsForm.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form;
+
+use Yiisoft\Form\FormModel;
+use Yiisoft\Arrays\ArrayHelper;
+
+final class DynamicFieldsForm extends FormModel
+{
+    private array $fields = [];
+
+    public function __construct(array $fields = [])
+    {
+        $this->fields = $fields;
+
+        parent::__construct();
+    }
+
+    public function hasAttribute(string $attribute): bool
+    {
+        if (ArrayHelper::keyExists($this->fields, $attribute)) {
+            return true;
+        }
+
+        return parent::hasAttribute($attribute);
+    }
+
+    public function getAttributeValue(string $attribute)
+    {
+        if (ArrayHelper::keyExists($this->fields, $attribute)) {
+            return $this->fields[$attribute];
+        }
+
+        return parent::getAttributeValue();
+    }
+
+    public function setAttribute(string $name, $value): void
+    {
+        if (ArrayHelper::keyExists($this->fields, $name)) {
+            $this->fields[$name] = $value;
+        } else {
+            parent::setAttribute($name, $value);
+        }
+    }
+}

--- a/tests/TestSupport/Form/DynamicFieldsForm.php
+++ b/tests/TestSupport/Form/DynamicFieldsForm.php
@@ -33,7 +33,7 @@ final class DynamicFieldsForm extends FormModel
             return $this->fields[$attribute];
         }
 
-        return parent::getAttributeValue();
+        return parent::getAttributeValue($attribute);
     }
 
     public function setAttribute(string $name, $value): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌

Allow symbols like "-" or "_" in attribute name. For example - for dynamic forms where field stored in DB and as uuid/random string format
