### PR TITLE
Allow nested attributes as array

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -247,8 +247,13 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
 
             /** @var ReflectionNamedType|null $type */
             $type = $property->getType();
+            $name = $property->getName();
 
-            $attributes[$property->getName()] = $type !== null ? $type->getName() : '';
+            $attributes[$name] = $type !== null ? $type->getName() : '';
+
+            if ($property->allowsNull()) {
+                $this->nullable[] = $name;
+            }
         }
 
         return $attributes;

--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -104,18 +104,12 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
         return [];
     }
 
-    /**
-     * @return iterable|object|scalar|Stringable|null
-     */
-    public function getAttributeCastValue(string $attribute, string ...$nested)
+    public function getAttributeCastValue(string $attribute, string ...$nested): mixed
     {
         return $this->readProperty($attribute, ...$nested);
     }
 
-    /**
-     * @return iterable|object|scalar|Stringable|null
-     */
-    public function getAttributeRawValue(string $attribute, string ...$nested)
+    public function getAttributeRawValue(string $attribute, string ...$nested): mixed
     {
         [$attribute, $nested] = $this->getNestedAttribute($attribute, ...$nested);
 
@@ -126,10 +120,7 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
         return $this->rawData[$attribute] ?? null;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getAttributeValue(string $attribute, string ...$nested)
+    public function getAttributeValue(string $attribute, string ...$nested): mixed
     {
         return $this->getAttributeRawValue($attribute, ...$nested) ?? $this->getAttributeCastValue($attribute, ...$nested);
     }

--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -10,6 +10,7 @@ use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionUnionType;
 use RuntimeException;
+use Throwable;
 use Yiisoft\Strings\Inflector;
 use Yiisoft\Strings\StringHelper;
 use Yiisoft\Validator\PostValidationHookInterface;
@@ -158,7 +159,18 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
     {
         [$attribute, $nested] = $this->getNestedAttribute($attribute, ...$nested);
 
-        return $nested !== null || array_key_exists($attribute, $this->attributes);
+        if ($nested === null) {
+            return array_key_exists($attribute, $this->attributes);
+        }
+
+        try {
+            /** @var bool */
+            return $this->getNestedAttributeValue('hasAttribute', $attribute, ...$nested);
+        } catch (InvalidArgumentException $ex) {
+            return false;
+        } catch (Throwable $ex) {
+            throw $ex;
+        }
     }
 
     /**

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -11,6 +11,7 @@ use Yiisoft\Form\Tests\TestSupport\CustomFormErrors;
 use Yiisoft\Form\Tests\TestSupport\Form\CustomFormNameForm;
 use Yiisoft\Form\Tests\TestSupport\Form\DefaultFormNameForm;
 use Yiisoft\Form\Tests\TestSupport\Form\FormWithNestedAttribute;
+use Yiisoft\Form\Tests\TestSupport\Form\FormWithDeepNested;
 use Yiisoft\Form\Tests\TestSupport\Form\LoginForm;
 use Yiisoft\Form\Tests\TestSupport\Form\TypeForm;
 use Yiisoft\Form\Tests\TestSupport\TestTrait;
@@ -84,6 +85,7 @@ final class FormModelTest extends TestCase
         $form = new FormWithNestedAttribute();
 
         $this->assertSame('Write your id or email.', $form->getAttributeHint('user.login'));
+        $this->assertSame('Write your id or email.', $form->getAttributeHint('user', 'login'));
     }
 
     public function testGetNestedAttributeLabel(): void
@@ -91,6 +93,7 @@ final class FormModelTest extends TestCase
         $form = new FormWithNestedAttribute();
 
         $this->assertSame('Login:', $form->getAttributeLabel('user.login'));
+        $this->assertSame('Login:', $form->getAttributeLabel('user', 'login'));
     }
 
     public function testGetNestedAttributePlaceHolder(): void
@@ -98,6 +101,7 @@ final class FormModelTest extends TestCase
         $form = new FormWithNestedAttribute();
 
         $this->assertSame('Type Usernamer or Email.', $form->getAttributePlaceHolder('user.login'));
+        $this->assertSame('Type Usernamer or Email.', $form->getAttributePlaceHolder('user', 'login'));
     }
 
     public function testGetAttributePlaceHolder(): void
@@ -140,6 +144,7 @@ final class FormModelTest extends TestCase
 
         $form->setUserLogin('admin');
         $this->assertSame('admin', $form->getAttributeValue('user.login'));
+        $this->assertSame('admin', $form->getAttributeValue('user', 'login'));
     }
 
     public function testHasAttribute(): void
@@ -160,6 +165,9 @@ final class FormModelTest extends TestCase
         $this->assertTrue($form->hasAttribute('user.login'));
         $this->assertTrue($form->hasAttribute('user.password'));
         $this->assertTrue($form->hasAttribute('user.rememberMe'));
+        $this->assertTrue($form->hasAttribute('user', 'login'));
+        $this->assertTrue($form->hasAttribute('user', 'password'));
+        $this->assertTrue($form->hasAttribute('user', 'rememberMe'));
         $this->assertFalse($form->hasAttribute('noexist'));
     }
 
@@ -333,6 +341,34 @@ final class FormModelTest extends TestCase
 
         $formModel->setFormErrors($formErrors);
         $this->assertSame($formErrors, $formModel->getFormErrors());
+    }
+
+    public function testDeepNestedForm(): void
+    {
+        $form = new FormWithDeepNested();
+        $form->load([
+            'intValue' => 1,
+            'nestedForm.id' => 10,
+            'nestedForm.user.login' => 'test',
+            'nestedForm' => [
+                'user' => [
+                    'rememberMe' => true
+                ]
+            ]
+        ], '');
+
+        $form->setAttribute('personalForm.email', 'test@test.com');
+
+        $this->assertTrue($form->hasAttribute('nestedForm', 'user', 'password'));
+        $this->assertTrue($form->getAttributeValue('nestedForm.user.rememberMe'));
+        $this->assertTrue($form->getAttributeValue('nestedForm', 'user', 'rememberMe'));
+        $this->assertSame(1, $form->getAttributeValue('intValue'));
+        $this->assertSame(10, $form->getAttributeValue('nestedForm.id'));
+        $this->assertSame(10, $form->getAttributeValue('nestedForm', 'id'));
+        $this->assertSame('test', $form->getAttributeValue('nestedForm.user.login'));
+        $this->assertSame('test', $form->getAttributeValue('nestedForm', 'user', 'login'));
+        $this->assertSame('test@test.com', $form->getAttributeValue('personalForm.email'));
+        $this->assertSame('test@test.com', $form->getAttributeValue('personalForm', 'email'));
     }
 
     public function testSetAttribute(): void

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -261,6 +261,22 @@ final class FormModelTest extends TestCase
         $this->assertSame('admin', $form->getUserLogin());
     }
 
+    public function testLoadWithNestedAttributeArray(): void
+    {
+        $form = new FormWithNestedAttribute();
+
+        $data = [
+            'FormWithNestedAttribute' => [
+                'user' => [
+                    'login' => 'admin',
+                ],
+            ],
+        ];
+
+        $this->assertTrue($form->load($data));
+        $this->assertSame('admin', $form->getUserLogin());
+    }
+
     public function testNonNamespacedFormName(): void
     {
         $form = new \NonNamespacedForm();

--- a/tests/FormNestedTest.php
+++ b/tests/FormNestedTest.php
@@ -159,7 +159,7 @@ final class FormNestedTest extends TestCase
     public function testLoad(array $data, array $expected): void
     {
         $form = new DataSearchForm();
-        $form->load($data, '');
+        $this->assertTrue($form->load($data, ''));
 
         foreach ($expected as $name => $value) {
             $this->assertSame($value, $form->getAttributeValue($name));

--- a/tests/FormNestedTest.php
+++ b/tests/FormNestedTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests;
+
+use InvalidArgumentException;
+use Yiisoft\Form\Tests\TestSupport\Form\Nested\DataSearchForm;
+use PHPUnit\Framework\TestCase;
+
+final class FormNestedTest extends TestCase
+{
+    public function loadDataProvider(): array
+    {
+        return [
+            [
+                'data' => [
+                   'area' => [100, 200],
+                   'price' => ['1000'],
+                   'address' => [
+                       'type_id' => 1,
+                       'fiases' => [
+                           'a2b487e8-b4db-11ec-b909-0242ac120002',
+                           '21950189-d579-40c1-8768-010844f4e88d',
+                        ],
+                        'pageData' => [
+                            'ids' => [1, 2, 5],
+                            'page' => [
+                                'source_ids' => 10
+                            ]
+                        ]
+                    ],
+                    'address.query' => 'some street name',
+                    'address.pageData.fiases' => '2198a8fb-2dcb-4009-8b55-9799df9c6385',
+                    'address.numbers.numbers' => [10, 40, 400],
+                ],
+                'expected' => [
+                    'area' => [100, 200],
+                    'price' => ['1000'],
+                    'address.type_id' => 1,
+                    'address.fiases' => [
+                        'a2b487e8-b4db-11ec-b909-0242ac120002',
+                        '21950189-d579-40c1-8768-010844f4e88d',
+                    ],
+                    'address.query' => 'some street name',
+                    'address.pageData.ids' => [1, 2, 5],
+                    'address.pageData.fiases' => [
+                        '2198a8fb-2dcb-4009-8b55-9799df9c6385',
+                    ],
+                    'address.numbers.numbers' => [10, 40, 400],
+                    'address.pageData.page.source_ids' => [10],
+                ],
+            ],
+        ];
+    }
+
+    public function testGetAttributeHint(): void
+    {
+        $form = new DataSearchForm();
+
+        //main
+        $this->assertSame('ID of auction type', $form->getAttributeHint('auction_type_id'));
+
+        //2st level
+        $this->assertSame('ID of address type', $form->getAttributeHint('address', 'type_id'));
+        $this->assertSame('Address name starts with...', $form->getAttributeHint('address', 'query'));
+        $this->assertSame('ID of address type', $form->getAttributeHint('address.type_id'));
+        $this->assertSame('Address name starts with...', $form->getAttributeHint('address.query'));
+
+        //4th level
+        $this->assertSame('IDs of sources', $form->getAttributeHint('address', 'pageData', 'page', 'source_ids'));
+        $this->assertSame('IDs of urls', $form->getAttributeHint('address', 'pageData', 'page', 'url_ids'));
+        $this->assertSame('IDs of sources', $form->getAttributeHint('address.pageData.page.source_ids'));
+        $this->assertSame('IDs of urls', $form->getAttributeHint('address.pageData.page.url_ids'));
+    }
+
+    public function testGetAttributeLabel(): void
+    {
+        $form = new DataSearchForm();
+
+        //main
+        $this->assertSame('Auction type', $form->getAttributeLabel('auction_type_id'));
+        $this->assertSame('Sources', $form->getAttributeLabel('source_ids'));
+
+        //2th level
+        $this->assertSame('FIAS numbers', $form->getAttributeLabel('address', 'fiases'));
+        $this->assertSame('FIAS numbers', $form->getAttributeLabel('address.fiases'));
+
+        //3th level
+        $this->assertSame('Data ID', $form->getAttributeLabel('address', 'pageData', 'ids'));
+        $this->assertSame('Data ID', $form->getAttributeLabel('address.pageData.ids'));
+
+        //4th level
+        $this->assertSame('Sources', $form->getAttributeLabel('address', 'pageData', 'page', 'source_ids'));
+        $this->assertSame('Sources', $form->getAttributeLabel('address.pageData.page.source_ids'));
+        $this->assertSame('URLs', $form->getAttributeLabel('address', 'pageData', 'page', 'url_ids'));
+        $this->assertSame('URLs', $form->getAttributeLabel('address.pageData.page.url_ids'));
+    }
+
+    public function testGetAttributePlaceHolder(): void
+    {
+        $form = new DataSearchForm();
+
+        //2th level
+        $this->assertSame('Start typing FIAS number', $form->getAttributePlaceholder('address', 'fiases'));
+        $this->assertSame('Start typing FIAS number', $form->getAttributePlaceholder('address.fiases'));
+
+        //3th level
+        $this->assertSame('Start typing number', $form->getAttributePlaceholder('address', 'numbers', 'numbers'));
+        $this->assertSame('Start typing number', $form->getAttributePlaceholder('address.numbers.numbers'));
+
+        //4th level
+        $this->assertSame('Start typing source name', $form->getAttributePlaceholder('address', 'pageData', 'page', 'source_ids'));
+        $this->assertSame('Start typing source name', $form->getAttributePlaceholder('address.pageData.page.source_ids'));
+    }
+
+    public function testGetAttributeValue(): void
+    {
+        $form = new DataSearchForm();
+
+        //2th level
+        $form->setAttribute('address.type_id', 10);
+        $this->assertSame(10, $form->getAttributeValue('address', 'type_id'));
+        $this->assertSame(10, $form->getAttributeValue('address.type_id'));
+
+        //3th level
+        $form->setAttribute('address.pageData.fiases', '123e4567-e89b-12d3-a456-426655440000');
+        $this->assertSame(['123e4567-e89b-12d3-a456-426655440000'], $form->getAttributeValue('address', 'pageData', 'fiases'));
+        $this->assertSame(['123e4567-e89b-12d3-a456-426655440000'], $form->getAttributeValue('address.pageData.fiases'));
+
+        //4th level
+        $form->setAttribute('address.pageData.page.source_ids', ['100', 200]);
+        $this->assertSame([100, 200], $form->getAttributeValue('address', 'pageData', 'page', 'source_ids'));
+        $this->assertSame([100, 200], $form->getAttributeValue('address.pageData.page.source_ids'));
+    }
+
+    public function testGetAttributeValueException(): void
+    {
+        $form = new DataSearchForm();
+        $this->expectException(InvalidArgumentException::class);
+        $form->getAttributeValue('noExist');
+        $form->getAttributeValue('address', 'noExist');
+        $form->getAttributeValue('address', 'pageData', 'noExist');
+    }
+
+    public function testHasAttribute(): void
+    {
+        $form = new DataSearchForm();
+
+        $this->assertTrue($form->hasAttribute('address.pageData.fiases'));
+        $this->assertTrue($form->hasAttribute('address', 'pageData', 'fiases'));
+        $this->assertFalse($form->hasAttribute('address.pageData.notExists'));
+        $this->assertFalse($form->hasAttribute('address', 'pageData', 'notExists'));
+    }
+
+    /**
+     * @dataProvider loadDataProvider
+     */
+    public function testLoad(array $data, array $expected): void
+    {
+        $form = new DataSearchForm();
+        $form->load($data, '');
+
+        foreach ($expected as $name => $value) {
+            $this->assertSame($value, $form->getAttributeValue($name));
+        }
+    }
+}

--- a/tests/TestSupport/Form/DynamicAttributesForm.php
+++ b/tests/TestSupport/Form/DynamicAttributesForm.php
@@ -13,12 +13,12 @@ final class DynamicAttributesForm extends FormModel
     {
     }
 
-    public function hasAttribute(string $attribute): bool
+    public function hasAttribute(string $attribute, string ...$nested): bool
     {
         return ArrayHelper::keyExists($this->attributes, $attribute);
     }
 
-    public function getAttributeValue(string $attribute): iterable|int|float|string|bool|object|null
+    public function getAttributeValue(string $attribute, string ...$nested): mixed
     {
         if ($this->hasAttribute($attribute)) {
             return $this->attributes[$attribute];

--- a/tests/TestSupport/Form/FormWithDeepNested.php
+++ b/tests/TestSupport/Form/FormWithDeepNested.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form;
+
+use Yiisoft\Form\FormModel;
+
+final class FormWithDeepNested extends FormModel
+{
+    protected int $intValue = 1;
+    protected PersonalForm $personalForm;
+    protected FormWithNestedAttribute $nestedForm;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->personalForm = new PersonalForm();
+        $this->nestedForm = new FormWithNestedAttribute();
+    }
+}

--- a/tests/TestSupport/Form/Nested/AddressSearchForm.php
+++ b/tests/TestSupport/Form/Nested/AddressSearchForm.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form\Nested;
+
+// use Brick\Geo\Geometry;
+// use Brick\Geo\IO\GeoJSONReader;
+
+
+use Yiisoft\Form\FormModel;
+
+/**
+ * Форма поиска адресов
+ */
+final class AddressSearchForm extends FormModel
+{
+    protected ?int $type_id = null;
+    protected ?array $fiases = null;
+    protected ?string $query = null;
+    protected mixed $ids = null;
+    protected mixed $k_numbers = null;
+    protected ?string $name = null;
+    protected bool $with_data = false;
+    protected mixed $regions = null;
+    //  protected ?Geometry $coords = null;
+
+    protected ObjectSearchForm $objects;
+    protected PageDataSearchForm $pageData;
+    protected NumberSearchForm $numbers;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->objects = new ObjectSearchForm();
+        $this->pageData = new PageDataSearchForm();
+        $this->numbers = new NumberSearchForm();
+    }
+
+    public function getAttributeHints(): array
+    {
+        $hints = parent::getAttributeHints();
+        $hints['type_id'] = 'ID of address type';
+        $hints['query'] = 'Address name starts with...';
+
+        return $hints;
+    }
+
+    public function getAttributeLabels(): array
+    {
+        $labels = parent::getAttributeLabels();
+        $labels['fiases'] = 'FIAS numbers';
+
+        return $labels;
+    }
+
+    public function getAttributePlaceholders(): array
+    {
+        $placeholders = parent::getAttributePlaceholders();
+        $placeholders['fiases'] = 'Start typing FIAS number';
+
+        return $placeholders;
+    }
+
+    public function setAttribute($name, $value): void
+    {
+        switch ($name) {
+            case 'fiases':
+                parent::setAttribute($name, empty($value) ? null : (array) $value);
+                break;
+            case 'type_id':
+                $this->type_id = is_numeric($value) ? (int) $value : null;
+                break;
+            case 'coords':
+             //   $this->setCoordinates($value);
+                break;
+            case 'ids':
+                if (empty($value)) {
+                    $value = null;
+                } elseif (is_array($value)) {
+                    $value = filter_var($value, FILTER_VALIDATE_INT, [
+                        'options' => [
+                            'min_range' => 1
+                        ],
+                        'flags' => FILTER_FORCE_ARRAY
+                    ]);
+                }
+
+                parent::setAttribute($name, $value);
+
+                break;
+            default:
+                parent::setAttribute($name, $value);
+        }
+    }
+}

--- a/tests/TestSupport/Form/Nested/DataSearchForm.php
+++ b/tests/TestSupport/Form/Nested/DataSearchForm.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\Form\Tests\TestSupport\Form\Nested;
 
 use Yiisoft\Form\FormModel;
-use function Safe\strtotime;
 
 final class DataSearchForm extends FormModel
 {
@@ -66,63 +65,5 @@ final class DataSearchForm extends FormModel
     public function getFormName(): string
     {
         return 'Search';
-    }
-
-    public function getMinPrice(): ?float
-    {
-        $min = $this->price[0] ?? null;
-
-        return filter_var($min, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
-    }
-
-    public function getMaxPrice(): ?float
-    {
-        $max = $this->price[1] ?? null;
-
-        return filter_var($max, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
-    }
-
-    public function getMinArea(): ?float
-    {
-        $min = $this->area[0] ?? null;
-
-        return filter_var($min, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
-    }
-
-    public function getMaxArea(): ?float
-    {
-        $max = $this->area[1] ?? null;
-
-        return filter_var($max, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
-    }
-
-    private function getDateTime(?string $value): ?string
-    {
-        if (empty($value) || ($timestamp = strtotime($value)) === false) {
-            return null;
-        }
-
-        return date('Y-m-d\TH:i', $timestamp);
-    }
-
-    public function getMinAcceptingBid(): ?string
-    {
-        return $this->getDateTime($this->accepting_bid[0] ?? null);
-    }
-
-    public function getMaxAcceptingBid(): ?string
-    {
-        return $this->getDateTime($this->accepting_bid[1] ?? null);
-    }
-
-
-    public function getMinAuctionTime(): ?string
-    {
-        return $this->getDateTime($this->auction_time[0] ?? null);
-    }
-
-    public function getMaxAuctionTime(): ?string
-    {
-        return $this->getDateTime($this->auction_time[1] ?? null);
     }
 }

--- a/tests/TestSupport/Form/Nested/DataSearchForm.php
+++ b/tests/TestSupport/Form/Nested/DataSearchForm.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form\Nested;
+
+use Yiisoft\Form\FormModel;
+use function Safe\strtotime;
+
+final class DataSearchForm extends FormModel
+{
+    protected ?int $auction_type_id = null;
+    protected ?array $source_ids = null;
+    protected array $price = [];
+    protected array $accepting_bid = [];
+    protected array $auction_time = [];
+    protected array $area = [];
+
+    protected AddressSearchForm $address;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->address = new AddressSearchForm();
+    }
+
+    public function getAttributeHints(): array
+    {
+        $hints = parent::getAttributeHints();
+        $hints['auction_type_id'] = 'ID of auction type';
+        $hints['source_ids'] = 'List IDs of sources';
+        $hints['price'] = 'Price range';
+        $hints['area'] = 'Area range';
+
+        return $hints;
+    }
+
+    public function getAttributeLabels(): array
+    {
+        $labels = parent::getAttributeLabels();
+        $labels['auction_type_id'] = 'Auction type';
+        $labels['source_ids'] = 'Sources';
+
+        return $labels;
+    }
+
+    public function setAttribute(string $name, $value): void
+    {
+        if ($name === 'source_ids') {
+            $value = empty($value) ? null : filter_var($value, FILTER_VALIDATE_INT, [
+                'options' => [
+                    'min_range' => 1
+                ],
+                'flags' => FILTER_FORCE_ARRAY
+            ]);
+        }
+        //if ($name === 'address.objects.type_ids') {
+        //  $this->address->setAttribute('objects.is_active', true);
+        // }
+
+        parent::setAttribute($name, $value);
+    }
+
+
+    public function getFormName(): string
+    {
+        return 'Search';
+    }
+
+    public function getMinPrice(): ?float
+    {
+        $min = $this->price[0] ?? null;
+
+        return filter_var($min, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
+    }
+
+    public function getMaxPrice(): ?float
+    {
+        $max = $this->price[1] ?? null;
+
+        return filter_var($max, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
+    }
+
+    public function getMinArea(): ?float
+    {
+        $min = $this->area[0] ?? null;
+
+        return filter_var($min, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
+    }
+
+    public function getMaxArea(): ?float
+    {
+        $max = $this->area[1] ?? null;
+
+        return filter_var($max, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
+    }
+
+    private function getDateTime(?string $value): ?string
+    {
+        if (empty($value) || ($timestamp = strtotime($value)) === false) {
+            return null;
+        }
+
+        return date('Y-m-d\TH:i', $timestamp);
+    }
+
+    public function getMinAcceptingBid(): ?string
+    {
+        return $this->getDateTime($this->accepting_bid[0] ?? null);
+    }
+
+    public function getMaxAcceptingBid(): ?string
+    {
+        return $this->getDateTime($this->accepting_bid[1] ?? null);
+    }
+
+
+    public function getMinAuctionTime(): ?string
+    {
+        return $this->getDateTime($this->auction_time[0] ?? null);
+    }
+
+    public function getMaxAuctionTime(): ?string
+    {
+        return $this->getDateTime($this->auction_time[1] ?? null);
+    }
+}

--- a/tests/TestSupport/Form/Nested/NumberSearchForm.php
+++ b/tests/TestSupport/Form/Nested/NumberSearchForm.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form\Nested;
+
+use Yiisoft\Form\FormModel;
+
+final class NumberSearchForm extends FormModel
+{
+    protected ?array $fiases = null;
+    protected mixed $numbers = null;
+
+    public function setAttribute(string $name, $value): void
+    {
+        if ($name === 'fiases') {
+            $value = empty($value) ? null : (array) $value;
+        }
+
+        parent::setAttribute($name, $value);
+    }
+
+    public function getAttributePlaceholders(): array
+    {
+        $placeholders = parent::getAttributePlaceholders();
+        $placeholders['numbers'] = 'Start typing number';
+
+        return $placeholders;
+    }
+}

--- a/tests/TestSupport/Form/Nested/ObjectSearchForm.php
+++ b/tests/TestSupport/Form/Nested/ObjectSearchForm.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form\Nested;
+
+use Yiisoft\Form\FormModel;
+
+final class ObjectSearchForm extends FormModel
+{
+    protected ?array $fiases = null;
+    protected ?array $type_ids = null;
+    protected ?bool $is_active = null;
+
+    public function setAttribute(string $name, $value): void
+    {
+        if ($name === 'fiases' || $name === 'type_ids') {
+            $value = empty($value) ? null : (array) $value;
+
+            parent::setAttribute($name, $value);
+        }
+
+        if ($name === 'is_active') {
+            $this->is_active  = $value === '' || $value === null ? null : (bool) $value;
+        }
+    }
+
+    public function getAttributeHints(): array
+    {
+        $hints = parent::getAttributeHints();
+        $hints['type_ids'] = 'IDs of object types';
+        $hints['fiases'] = 'List of address FIAS numbers';
+
+        return $hints;
+    }
+}

--- a/tests/TestSupport/Form/Nested/PageDataSearchForm.php
+++ b/tests/TestSupport/Form/Nested/PageDataSearchForm.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form\Nested;
+
+use Yiisoft\Form\FormModel;
+
+final class PageDataSearchForm extends FormModel
+{
+    protected ?array $fiases = null;
+    protected ?array $ids = null;
+
+    protected PageSearchForm $page;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->page = new PageSearchForm();
+    }
+
+    public function setAttribute(string $name, $value): void
+    {
+        if ($name === 'fiases') {
+            $value = empty($value) ? null : (array) $value;
+        } elseif ($name === 'ids') {
+            $value = empty($value) ? null : filter_var($value, FILTER_VALIDATE_INT, [
+                'options' => [
+                    'min_range' => 1
+                ],
+                'flags' => FILTER_FORCE_ARRAY
+            ]);
+        }
+
+        parent::setAttribute($name, $value);
+    }
+
+    public function getAttributeLabels(): array
+    {
+        $labels = parent::getAttributeLabels();
+        $labels['ids'] = 'Data ID';
+
+        return $labels;
+    }
+}

--- a/tests/TestSupport/Form/Nested/PageSearchForm.php
+++ b/tests/TestSupport/Form/Nested/PageSearchForm.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form\Nested;
+
+use Yiisoft\Form\FormModel;
+
+final class PageSearchForm extends FormModel
+{
+    protected ?array $source_ids = null;
+    protected ?array $url_ids = null;
+
+    public function setAttribute(string $name, $value): void
+    {
+        if ($name === 'source_ids' || $name === 'url_ids') {
+            $value = empty($value) ? null : filter_var($value, FILTER_VALIDATE_INT, [
+                'options' => [
+                    'min_range' => 1
+                ],
+                'flags' => FILTER_FORCE_ARRAY
+            ]);
+        }
+
+        parent::setAttribute($name, $value);
+    }
+
+    public function getAttributeHints(): array
+    {
+        $hints = parent::getAttributeHints();
+        $hints['source_ids'] = 'IDs of sources';
+        $hints['url_ids'] = 'IDs of urls';
+
+        return $hints;
+    }
+
+    public function getAttributeLabels(): array
+    {
+        $labels = parent::getAttributeLabels();
+        $labels['source_ids'] = 'Sources';
+        $labels['url_ids'] = 'URLs';
+
+        return $labels;
+    }
+
+    public function getAttributePlaceholders(): array
+    {
+        $placeholders = parent::getAttributePlaceholders();
+        $placeholders['source_ids'] = 'Start typing source name';
+
+        return $placeholders;
+    }
+}

--- a/tests/Widget/Field/FieldNumberTest.php
+++ b/tests/Widget/Field/FieldNumberTest.php
@@ -324,7 +324,7 @@ final class FieldNumberTest extends TestCase
         $expected = <<<'HTML'
         <div>
         <label for="typeform-number">Number</label>
-        <input type="number" id="typeform-number" name="TypeForm[number]" value="0">
+        <input type="number" id="typeform-number" name="TypeForm[number]">
         </div>
         HTML;
         $this->assertEqualsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

1. Allow deep nested forms
2. Allow old syntax with **dot** and new separate syntax. For example `getAttributeValue('attribute', 'nested-1', 'nested-2')`
3. Allow both syntax for  **load** nesteds `FormModel`. Previous `attribute.nested = value` and as simple array (for example from $_GET/$_POST)

```
[
    'attribute' => [
        'nested' => 'value',
    ],
]
```
4. Allow nullable property
5. Fix union type error