### PR TITLE
Set proper attribute name in Form::enctype() method

### DIFF
--- a/src/Widget/Form.php
+++ b/src/Widget/Form.php
@@ -194,7 +194,7 @@ final class Form extends Widget
     public function enctype(string $value): self
     {
         $new = clone $this;
-        $new->attributes['id'] = $value;
+        $new->attributes['enctype'] = $value;
         return $new;
     }
 

--- a/tests/Widget/FormTest.php
+++ b/tests/Widget/FormTest.php
@@ -155,7 +155,7 @@ final class FormTest extends TestCase
     public function testEnctype(): void
     {
         $this->assertSame(
-            '<form id="multipart/form-data" method="POST">',
+            '<form enctype="multipart/form-data" method="POST">',
             Form::widget()->enctype('multipart/form-data')->begin(),
         );
     }

--- a/tests/Widget/FormTest.php
+++ b/tests/Widget/FormTest.php
@@ -155,7 +155,7 @@ final class FormTest extends TestCase
     public function testEnctype(): void
     {
         $this->assertSame(
-            '<form enctype="multipart/form-data" method="POST">',
+            '<form method="POST" enctype="multipart/form-data">',
             Form::widget()->enctype('multipart/form-data')->begin(),
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
