### PR TITLE
Add type hint `array|object|null` to data of `FormModel::load()`

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -31,7 +31,6 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
     private array $attributes;
     private ?FormErrorsInterface $formErrors = null;
     private ?Inflector $inflector = null;
-    /** @psalm-var array<string, string|array> */
     private array $rawData = [];
     private bool $validated = false;
 
@@ -147,28 +146,29 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
         return $nested !== null || array_key_exists($attribute, $this->attributes);
     }
 
-    /**
-     * @param array $data
-     * @param string|null $formName
-     *
-     * @return bool
-     *
-     * @psalm-param array<string, string|array> $data
-     */
-    public function load(array $data, ?string $formName = null): bool
+    public function load(array|object|null $data, ?string $formName = null): bool
     {
+        if (!is_array($data)) {
+            return false;
+        }
+
         $this->rawData = [];
         $scope = $formName ?? $this->getFormName();
 
         if ($scope === '' && !empty($data)) {
             $this->rawData = $data;
         } elseif (isset($data[$scope])) {
-            /** @var array<string, string> */
+            if (!is_array($data[$scope])) {
+                return false;
+            }
             $this->rawData = $data[$scope];
         }
 
+        /**
+         * @var mixed $value
+         */
         foreach ($this->rawData as $name => $value) {
-            $this->setAttribute($name, $value);
+            $this->setAttribute((string) $name, $value);
         }
 
         return $this->rawData !== [];

--- a/src/FormModelInterface.php
+++ b/src/FormModelInterface.php
@@ -120,14 +120,12 @@ interface FormModelInterface extends DataSetInterface, FormMetadataInterface
      * `$formName` parameter is given. If the form name is empty string, `load()` populates the model with the whole of
      * `$data` instead of `$data['FormName']`.
      *
-     * @param array $data the data array to load, typically server request attributes.
+     * @param array|object|null $data The data to load, typically server request attributes.
      * @param string|null $formName scope from which to get data
      *
      * @return bool whether `load()` found the expected form in `$data`.
-     *
-     * @psalm-param array<string, string> $data
      */
-    public function load(array $data, ?string $formName = null): bool;
+    public function load(array|object|null $data, ?string $formName = null): bool;
 
     /**
      * Set specified attribute

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Form\Tests;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Yiisoft\Form\FormModel;
 use Yiisoft\Form\Tests\TestSupport\CustomFormErrors;
 use Yiisoft\Form\Tests\TestSupport\Form\CustomFormNameForm;
@@ -259,6 +260,33 @@ final class FormModelTest extends TestCase
 
         $this->assertTrue($form->load($data));
         $this->assertSame('admin', $form->getUserLogin());
+    }
+
+    public function testLoadObjectData(): void
+    {
+        $form = new LoginForm();
+
+        $result = $form->load(new stdClass());
+
+        $this->assertFalse($result);
+    }
+
+    public function testLoadNullData(): void
+    {
+        $form = new LoginForm();
+
+        $result = $form->load(null);
+
+        $this->assertFalse($result);
+    }
+
+    public function testLoadNonArrayScopedData(): void
+    {
+        $form = new LoginForm();
+
+        $result = $form->load(['LoginForm' => null]);
+
+        $this->assertFalse($result);
     }
 
     public function testNonNamespacedFormName(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

**Why?**

Popular case:

```php
$form->load($request->getParsedBody())
```

But `Psr\Http\Message\ServerRequestInterface::getParsedBody()` returns `null|array|object`.