### PR TITLE
LoadMultipleTrait

### DIFF
--- a/src/LoadMultipleTrait.php
+++ b/src/LoadMultipleTrait.php
@@ -6,9 +6,6 @@ namespace Yiisoft\Form;
 
 trait LoadMultipleTrait
 {
-    /**
-     * @param FormModelInterface[] Loaded models
-     */
     private array $models = [];
 
     public function loadMultiple(array $data, ?string $formName = null): bool
@@ -18,6 +15,7 @@ trait LoadMultipleTrait
             $formName = $this->getFormName();
         }
 
+        $success = true;
         foreach (array_keys($data) as $i) {
             /* @var \Yiisoft\Form\FormModelInterface $model */
             $model = clone $this;
@@ -32,11 +30,11 @@ trait LoadMultipleTrait
             if ($result === true) {
                 $this->models[] = $model;
             } else {
-                break;
+                $this->models[] = $success = false;
             }
         }
 
-        return count($this->models) === count($data);
+        return $success;
     }
 
     public function getModels(): array

--- a/src/LoadMultipleTrait.php
+++ b/src/LoadMultipleTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form;
+
+trait LoadMultipleTrait
+{
+    /**
+     * @param FormModelInterface[] Loaded models
+     */
+    private array $models = [];
+
+    public function loadMultiple(array $data, ?string $formName = null): bool
+    {
+        if ($formName === null) {
+            /* @var \Yiisoft\Form\FormModelInterface $this */
+            $formName = $this->getFormName();
+        }
+
+        foreach (array_keys($data) as $i) {
+            /* @var \Yiisoft\Form\FormModelInterface $model */
+            $model = clone $this;
+
+            $result = false;
+            if ($formName === '' && !empty($data[$i])) {
+                $result = $model->load($data[$i], '');
+            } elseif (!empty($data[$formName][$i])) {
+                $result = $model->load($data[$formName][$i], '');
+            }
+
+            if ($result === true) {
+                $this->models[] = $model;
+            } else {
+                break;
+            }
+        }
+
+        return count($this->models) === count($data);
+    }
+
+    public function getModels(): array
+    {
+        return $this->models;
+    }
+}

--- a/src/LoadMultipleTrait.php
+++ b/src/LoadMultipleTrait.php
@@ -15,19 +15,17 @@ trait LoadMultipleTrait
             $formName = $this->getFormName();
         }
 
+        if ($formName !== '') {
+            $data = $data[$formName];
+        }
+
         $success = true;
+
         foreach (array_keys($data) as $i) {
             /* @var \Yiisoft\Form\FormModelInterface $model */
             $model = clone $this;
 
-            $result = false;
-            if ($formName === '' && !empty($data[$i])) {
-                $result = $model->load($data[$i], '');
-            } elseif (!empty($data[$formName][$i])) {
-                $result = $model->load($data[$formName][$i], '');
-            }
-
-            if ($result === true) {
+            if ($model->load($data[$i], '') === true) {
                 $this->models[] = $model;
             } else {
                 $this->models[] = $success = false;

--- a/tests/MultipleFormModelTest.php
+++ b/tests/MultipleFormModelTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Form\FormModel;
+use Yiisoft\Form\Tests\TestSupport\Form\LoadMultipleForm;
+use Yiisoft\Form\Tests\TestSupport\TestTrait;
+
+require __DIR__ . '/TestSupport/Form/NonNamespacedForm.php';
+
+final class MultipleFormModelTest extends TestCase
+{
+    use TestTrait;
+
+    /*
+    public function testLoadMultiple(): void
+    {
+        $form = new LoadMultipleForm();
+        $formName = $form->getFormName();
+
+        $data = [
+            $formName => [
+                [
+                    'attribute1' => 'b5HhRBieacLZki2H',
+                    'attribute2' => 'eu3VXDpwvvyoahwNAjPmjYV7PgCEZ9pTAWAf',
+                    'attribute3' => 'ym8ES3nDhxN4',
+                    'attribute4' => 'CupHZ4Ljzeym8q8Hmu8',
+                ],
+                [
+                    'attribute1' => 's8rcuBHjZ4MXEkGU2YToFGz9XTADyg4j8ibZ',
+                    'attribute2' => 'eDruLPmPkALRE7qUyhDapJZTTnE2A',
+                    'attribute3' => '2f6ot3S5f8T7tNm5',
+                    'attribute4' => 'rYNM4jfZ7kFCN6A4i7apSMFPxq',
+                ],
+                [
+                    'attribute1' => '64brF469aKhY',
+                    'attribute2' => 'J3BSpg4rVY6mVq5cTu',
+                    'attribute3' => 'h8VpgtLbwz6WyUhCLgFgg5wkdqtmmBy5HE5U',
+                    'attribute4' => '6yDHpqf357fEcKsYeJz',
+                ],
+                [
+                    'attribute1' => 'Mqx6LL78mysscsaHLhSSM46Uht46tdAvaejs',
+                    'attribute2' => '7PqV94mzGL2tP',
+                    'attribute3' => 'K7ZvDNkEv4cwsPpTEpBsJEu7',
+                    'attribute4' => 'CtsAPJQnUUCgKFGfvQ6C',
+                ],
+                [
+                    'attribute1' => '49xuodLX3XPb9LueLSUq7GbhdRa3aw',
+                    'attribute2' => '2MHboYwmBLXyWYPJoXeoKLjVS',
+                    'attribute3' => 'p6AJiq3NQsW4dwcKAz',
+                    'attribute4' => 'JetmdpKiVXMYBs3CLvQb7qEvyQDFXELDAeCb',
+                ],
+            ],
+        ];
+
+        $this->assertTrue($form->loadMultiple($data));
+
+        $models = $form->getModels();
+
+        $this->assertCount(count($data[$formName]), $models);
+
+        foreach ($models as $i => $model) {
+            $this->assertInstanceOf(LoadMultipleForm::class, $model);
+            $this->assertSame($data[$formName][$i], $model->getData());
+        }
+    }
+    */
+
+    public function testLoadFailedForm(): void
+    {
+        $form = new LoadMultipleForm();
+        $formName = $form->getFormName();
+
+        $data = [
+            $formName => [
+                [
+                    'attribute1' => 'b5HhRBieacLZki2H',
+                    'attribute2' => 'eu3VXDpwvvyoahwNAjPmjYV7PgCEZ9pTAWAf',
+                    'attribute3' => 'ym8ES3nDhxN4',
+                    'attribute4' => 'CupHZ4Ljzeym8q8Hmu8',
+                ],
+                [
+                    'attribute1' => 's8rcuBHjZ4MXEkGU2YToFGz9XTADyg4j8ibZ',
+                    'attribute2' => 'eDruLPmPkALRE7qUyhDapJZTTnE2A',
+                    'attribute3' => '2f6ot3S5f8T7tNm5',
+                    'attribute4' => 'rYNM4jfZ7kFCN6A4i7apSMFPxq',
+                ],
+                [
+                    'attribute1' => '64brF469aKhY',
+                    'attribute2' => 'J3BSpg4rVY6mVq5cTu',
+                    'attribute3' => 'h8VpgtLbwz6WyUhCLgFgg5wkdqtmmBy5HE5U',
+                    'attribute4' => '6yDHpqf357fEcKsYeJz',
+                ],
+                [
+                    // empty data to cause loading failure
+                ],
+                [
+                    'attribute1' => '49xuodLX3XPb9LueLSUq7GbhdRa3aw',
+                    'attribute2' => '2MHboYwmBLXyWYPJoXeoKLjVS',
+                    'attribute3' => 'p6AJiq3NQsW4dwcKAz',
+                    'attribute4' => 'JetmdpKiVXMYBs3CLvQb7qEvyQDFXELDAeCb',
+                ],
+            ],
+        ];
+
+        $this->assertFalse($form->loadMultiple($data));
+
+        $models = $form->getModels();
+
+        $this->assertCount(count($data[$formName]), $models);
+
+        foreach ($models as $i => $model) {
+            if (empty($data[$formName][$i])) {
+                $this->assertFalse($model);
+            } else {
+                $this->assertInstanceOf(LoadMultipleForm::class, $model);
+                $this->assertSame($data[$formName][$i], $model->getData());
+            }
+        }
+    }
+}

--- a/tests/TestSupport/Form/LoadMultipleForm.php
+++ b/tests/TestSupport/Form/LoadMultipleForm.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Form\Tests\TestSupport\Form;
+
+use Yiisoft\Form\FormModel;
+use Yiisoft\Form\LoadMultipleTrait;
+
+final class LoadMultipleForm extends FormModel
+{
+    use LoadMultipleTrait;
+
+    private string $attribute1 = '';
+    private string $attribute2 = '';
+    private string $attribute3 = '';
+    private string $attribute4 = '';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

Trait to be used in Form models.

Adds two methods:

loadMultiple() to load multiple models
getModels() to get the loaded models

#Usage
```php
class MyFormModel extends FormModel
{
    use Yiisoft\Form\LoadMultipleTrait;

    ...
}
```

In an action
```php
    ....

    $form = new MyFormModel();

    if ($form->loadMultiple($request->getParsedBody())) {
        foreach ($form->getModels() as $i => $model) {
            if (!$validator->validate($model)
                ->isValid()) {
                throw new \Exception("Validation failed at $i");
            }
        }

        // persist the models and send response
    }

```
