### PR TITLE
Allow null with method `setAttribute()` in `FormModel::class`.

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -176,20 +176,22 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
 
     public function setAttribute(string $name, mixed $value): void
     {
-        [$realName] = $this->getNestedAttribute($name);
+        if ($value !== null) {
+            [$realName] = $this->getNestedAttribute($name);
 
-        if (isset($this->attributes[$realName])) {
-            /** @var mixed */
-            $value = match ($this->attributes[$realName]) {
-                'bool' => (bool) $value,
-                'float' => (float) $value,
-                'int' => (int) $value,
-                'string' => (string) $value,
-                default => $value,
-            };
-
-            $this->writeProperty($name, $value);
+            if (isset($this->attributes[$realName])) {
+                /** @var mixed */
+                $value = match ($this->attributes[$realName]) {
+                    'bool' => (bool) $value,
+                    'float' => (float) $value,
+                    'int' => (int) $value,
+                    'string' => (string) $value,
+                    default => $value,
+                };
+            }
         }
+
+        $this->writeProperty($name, $value);
     }
 
     public function processValidationResult(Result $result): void

--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -176,19 +176,21 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
 
     public function setAttribute(string $name, mixed $value): void
     {
-        if ($value !== null) {
-            [$realName] = $this->getNestedAttribute($name);
+        if ($this->hasAttribute($name) === false) {
+            return;
+        }
 
-            if (isset($this->attributes[$realName])) {
-                /** @var mixed */
-                $value = match ($this->attributes[$realName]) {
-                    'bool' => (bool) $value,
-                    'float' => (float) $value,
-                    'int' => (int) $value,
-                    'string' => (string) $value,
-                    default => $value,
-                };
-            }
+        [$realName] = $this->getNestedAttribute($name);
+
+        if ($value !== null) {
+            /** @var mixed */
+            $value = match ($this->attributes[$realName]) {
+                'bool' => (bool) $value,
+                'float' => (float) $value,
+                'int' => (int) $value,
+                'string' => (string) $value,
+                default => $value,
+            };
         }
 
         $this->writeProperty($name, $value);

--- a/tests/FormModelTest.php
+++ b/tests/FormModelTest.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Form\Tests;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use TypeError;
 use Yiisoft\Form\FormModel;
 use Yiisoft\Form\Tests\TestSupport\CustomFormErrors;
 use Yiisoft\Form\Tests\TestSupport\Form\CustomFormNameForm;
@@ -387,5 +388,28 @@ final class FormModelTest extends TestCase
         $form->load($data, '');
 
         $this->assertSame($data, $form->getData());
+    }
+
+    public function testSetAttributesWithNull(): void
+    {
+        $form = new class () extends FormModel {
+            private ?int $nullableProperty = 0;
+        };
+
+        $form->setAttribute('nullableProperty', null);
+        $this->assertSame(null, $form->getAttributeValue('nullableProperty'));
+    }
+
+    public function testSetAttributesTypeErrorException(): void
+    {
+        $form = new class () extends FormModel {
+            private int $int = 0;
+        };
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage(
+            'Cannot assign null to property Yiisoft\Form\FormModel@anonymous::$int of type int'
+        );
+        $form->setAttribute('int', null);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
