### PR TITLE
FormModel::attributes renamed FormModel::attributeTypes

### DIFF
--- a/src/FormModel.php
+++ b/src/FormModel.php
@@ -28,7 +28,7 @@ use function substr;
  */
 abstract class FormModel implements FormModelInterface, PostValidationHookInterface, RulesProviderInterface
 {
-    private array $attributes;
+    private array $attributeTypes;
     private ?FormErrorsInterface $formErrors = null;
     private ?Inflector $inflector = null;
     private array $rawData = [];
@@ -36,12 +36,12 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
 
     public function __construct()
     {
-        $this->attributes = $this->collectAttributes();
+        $this->attributeTypes = $this->collectAttributes();
     }
 
     public function attributes(): array
     {
-        return array_keys($this->attributes);
+        return array_keys($this->attributeTypes);
     }
 
     public function getAttributeHint(string $attribute): string
@@ -143,7 +143,7 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
     {
         [$attribute, $nested] = $this->getNestedAttribute($attribute);
 
-        return $nested !== null || array_key_exists($attribute, $this->attributes);
+        return $nested !== null || array_key_exists($attribute, $this->attributeTypes);
     }
 
     public function load(array|object|null $data, ?string $formName = null): bool
@@ -184,7 +184,7 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
 
         if ($value !== null) {
             /** @var mixed */
-            $value = match ($this->attributes[$realName]) {
+            $value = match ($this->attributeTypes[$realName]) {
                 'bool' => (bool) $value,
                 'float' => (float) $value,
                 'int' => (int) $value,
@@ -342,7 +342,7 @@ abstract class FormModel implements FormModelInterface, PostValidationHookInterf
         [$attribute, $nested] = explode('.', $attribute, 2);
 
         /** @var string */
-        $attributeNested = $this->attributes[$attribute] ?? '';
+        $attributeNested = $this->attributeTypes[$attribute] ?? '';
 
         if (!is_subclass_of($attributeNested, self::class)) {
             throw new InvalidArgumentException("Attribute \"$attribute\" is not a nested attribute.");


### PR DESCRIPTION
Until I looked at the initialization `$attributes`, I thought it was an array of attribute names
`FormModel::attributes` is `[name attribute => type attribute]` 