### PR TITLE
Add methods `beforeInput()` and `afterInput()` to `PartsField`

### DIFF
--- a/src/Field/Base/PartsField.php
+++ b/src/Field/Base/PartsField.php
@@ -40,6 +40,9 @@ abstract class PartsField extends BaseField
     protected ?string $inputContainerTag = null;
     protected array $inputContainerAttributes = [];
 
+    private string|Stringable $beforeInput = '';
+    private string|Stringable $afterInput = '';
+
     private bool $replaceLabelAttributes = false;
     private bool $replaceLabelClass = false;
     private array $labelAttributes = [];
@@ -172,6 +175,20 @@ abstract class PartsField extends BaseField
     {
         $new = clone $this;
         Html::addCssClass($new->inputContainerAttributes, $class);
+        return $new;
+    }
+
+    final public function beforeInput(string|Stringable $content): static
+    {
+        $new = clone $this;
+        $new->beforeInput = $content;
+        return $new;
+    }
+
+    final public function afterInput(string|Stringable $content): static
+    {
+        $new = clone $this;
+        $new->afterInput = $content;
         return $new;
     }
 
@@ -412,7 +429,9 @@ abstract class PartsField extends BaseField
     {
         $parts = [
             '{input}' => $this->generateInputContainerBegin()
+                . $this->beforeInput
                 . $this->generateInput()
+                . $this->afterInput
                 . $this->generateInputContainerEnd(),
             '{label}' => ($this->hideLabel ?? $this->shouldHideLabel()) ? '' : $this->generateLabel(),
             '{hint}' => $this->generateHint(),

--- a/tests/Field/Base/PartsFieldTest.php
+++ b/tests/Field/Base/PartsFieldTest.php
@@ -784,4 +784,22 @@ final class PartsFieldTest extends TestCase
             $readyField->render()
         );
     }
+
+    public function testFullInput(): void
+    {
+        $field = StubPartsField::widget()
+            ->setInputHtml('<input>')
+            ->inputContainerTag('span')
+            ->beforeInput('before')
+            ->afterInput('after');
+
+        $this->assertSame(
+            <<<HTML
+            <div>
+            <span>before<input>after</span>
+            </div>
+            HTML,
+            $field->render()
+        );
+    }
 }

--- a/tests/Field/Base/PartsFieldTest.php
+++ b/tests/Field/Base/PartsFieldTest.php
@@ -750,4 +750,38 @@ final class PartsFieldTest extends TestCase
         $this->assertNotSame($field, $field->templateBegin(''));
         $this->assertNotSame($field, $field->templateEnd(''));
     }
+
+    public function testBeforeInput(): void
+    {
+        $field = StubPartsField::widget()->setInputHtml('<input>');
+
+        $readyField = $field->beforeInput('before');
+
+        $this->assertNotSame($field, $readyField);
+        $this->assertSame(
+            <<<HTML
+            <div>
+            before<input>
+            </div>
+            HTML,
+            $readyField->render()
+        );
+    }
+
+    public function testAfterInput(): void
+    {
+        $field = StubPartsField::widget()->setInputHtml('<input>');
+
+        $readyField = $field->afterInput('after');
+
+        $this->assertNotSame($field, $readyField);
+        $this->assertSame(
+            <<<HTML
+            <div>
+            <input>after
+            </div>
+            HTML,
+            $readyField->render()
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
