### PR TITLE
Restructure

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 /**
  * @var array $params

--- a/src/Field/Base/BaseField.php
+++ b/src/Field/Base/BaseField.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Form\Field\Base;
 
 use InvalidArgumentException;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\CustomTag;
 use Yiisoft\Widget\Widget;

--- a/src/Field/Base/DateTimeInputField.php
+++ b/src/Field/Base/DateTimeInputField.php
@@ -11,7 +11,7 @@ use Yiisoft\Form\Field\Base\EnrichFromValidationRules\EnrichFromValidationRulesI
 use Yiisoft\Form\Field\Base\EnrichFromValidationRules\EnrichFromValidationRulesTrait;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 use function is_string;

--- a/src/Field/Base/InputData/InputDataTrait.php
+++ b/src/Field/Base/InputData/InputDataTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Form\Field\Base\InputData;
 
+use Yiisoft\Form\PureField\InputData;
+
 trait InputDataTrait
 {
     private ?InputDataInterface $inputData = null;
@@ -18,7 +20,7 @@ trait InputDataTrait
     final protected function getInputData(): InputDataInterface
     {
         if ($this->inputData === null) {
-            $this->inputData = new PureInputData();
+            $this->inputData = new InputData();
         }
 
         return $this->inputData;

--- a/src/Field/Base/InputData/InputDataWithCustomNameAndValueTrait.php
+++ b/src/Field/Base/InputData/InputDataWithCustomNameAndValueTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Form\Field\Base\InputData;
 
+use Yiisoft\Form\PureField\InputData;
+
 /**
  * @psalm-type PrepareValueCallback = callable(mixed): mixed
  */
@@ -32,7 +34,7 @@ trait InputDataWithCustomNameAndValueTrait
     final protected function getInputData(): InputDataInterface
     {
         if ($this->inputData === null) {
-            $this->inputData = new PureInputData();
+            $this->inputData = new InputData();
         }
 
         return $this->inputData;

--- a/src/Field/Email.php
+++ b/src/Field/Email.php
@@ -12,7 +12,7 @@ use Yiisoft\Form\Field\Base\Placeholder\PlaceholderInterface;
 use Yiisoft\Form\Field\Base\Placeholder\PlaceholderTrait;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 use function is_string;

--- a/src/Field/File.php
+++ b/src/Field/File.php
@@ -10,7 +10,7 @@ use Yiisoft\Form\Field\Base\EnrichFromValidationRules\EnrichFromValidationRulesT
 use Yiisoft\Form\Field\Base\InputField;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 /**

--- a/src/Field/Number.php
+++ b/src/Field/Number.php
@@ -13,7 +13,7 @@ use Yiisoft\Form\Field\Base\Placeholder\PlaceholderInterface;
 use Yiisoft\Form\Field\Base\Placeholder\PlaceholderTrait;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 /**

--- a/src/Field/Part/Error.php
+++ b/src/Field/Part/Error.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Form\Field\Part;
 use InvalidArgumentException;
 use Yiisoft\Form\Field\Base\InputData\InputDataInterface;
 use Yiisoft\Form\Field\Base\InputData\InputDataTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\CustomTag;
 use Yiisoft\Widget\Widget;

--- a/src/Field/Part/Hint.php
+++ b/src/Field/Part/Hint.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Form\Field\Part;
 use InvalidArgumentException;
 use Stringable;
 use Yiisoft\Form\Field\Base\InputData\InputDataTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 use Yiisoft\Widget\Widget;
 

--- a/src/Field/Part/Label.php
+++ b/src/Field/Part/Label.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Form\Field\Part;
 
 use Stringable;
 use Yiisoft\Form\Field\Base\InputData\InputDataTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 use Yiisoft\Widget\Widget;
 

--- a/src/Field/Password.php
+++ b/src/Field/Password.php
@@ -12,7 +12,7 @@ use Yiisoft\Form\Field\Base\Placeholder\PlaceholderInterface;
 use Yiisoft\Form\Field\Base\Placeholder\PlaceholderTrait;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 use function is_string;

--- a/src/Field/Range.php
+++ b/src/Field/Range.php
@@ -11,7 +11,7 @@ use Yiisoft\Form\Field\Base\EnrichFromValidationRules\EnrichFromValidationRulesT
 use Yiisoft\Form\Field\Base\InputField;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 use function is_string;

--- a/src/Field/Select.php
+++ b/src/Field/Select.php
@@ -11,7 +11,7 @@ use Yiisoft\Form\Field\Base\EnrichFromValidationRules\EnrichFromValidationRulesT
 use Yiisoft\Form\Field\Base\InputField;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\Optgroup;
 use Yiisoft\Html\Tag\Option;
 use Yiisoft\Html\Tag\Select as SelectTag;

--- a/src/Field/Telephone.php
+++ b/src/Field/Telephone.php
@@ -12,7 +12,7 @@ use Yiisoft\Form\Field\Base\Placeholder\PlaceholderInterface;
 use Yiisoft\Form\Field\Base\Placeholder\PlaceholderTrait;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 use function is_string;

--- a/src/Field/Text.php
+++ b/src/Field/Text.php
@@ -12,7 +12,7 @@ use Yiisoft\Form\Field\Base\Placeholder\PlaceholderInterface;
 use Yiisoft\Form\Field\Base\Placeholder\PlaceholderTrait;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 use function is_string;

--- a/src/Field/Textarea.php
+++ b/src/Field/Textarea.php
@@ -12,7 +12,7 @@ use Yiisoft\Form\Field\Base\Placeholder\PlaceholderInterface;
 use Yiisoft\Form\Field\Base\Placeholder\PlaceholderTrait;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 use function is_string;

--- a/src/Field/Url.php
+++ b/src/Field/Url.php
@@ -12,7 +12,7 @@ use Yiisoft\Form\Field\Base\Placeholder\PlaceholderInterface;
 use Yiisoft\Form\Field\Base\Placeholder\PlaceholderTrait;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassInterface;
 use Yiisoft\Form\Field\Base\ValidationClass\ValidationClassTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 use function is_string;

--- a/src/PureField/Field.php
+++ b/src/PureField/Field.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form;
+namespace Yiisoft\Form\PureField;
 
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Button;
 use Yiisoft\Form\Field\ButtonGroup;
 use Yiisoft\Form\Field\Checkbox;
@@ -36,7 +35,7 @@ use Yiisoft\Form\Field\Url;
 /**
  * @psalm-import-type Errors from ErrorSummary
  */
-class PureField
+class Field
 {
     /**
      * @var string|null
@@ -66,7 +65,7 @@ class PureField
         ?string $theme = null,
     ): Checkbox {
         return Checkbox::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function checkboxList(
@@ -76,7 +75,7 @@ class PureField
         ?string $theme = null,
     ): CheckboxList {
         return CheckboxList::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function date(
@@ -86,7 +85,7 @@ class PureField
         ?string $theme = null,
     ): Date {
         return Date::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function dateTimeLocal(
@@ -96,7 +95,7 @@ class PureField
         ?string $theme = null,
     ): DateTimeLocal {
         return DateTimeLocal::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function email(
@@ -106,7 +105,7 @@ class PureField
         ?string $theme = null,
     ): Email {
         return Email::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     /**
@@ -132,7 +131,7 @@ class PureField
         ?string $theme = null,
     ): File {
         return File::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function hidden(
@@ -142,7 +141,7 @@ class PureField
         ?string $theme = null,
     ): Hidden {
         return Hidden::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function image(?string $url = null, array $config = [], ?string $theme = null): Image
@@ -163,7 +162,7 @@ class PureField
         ?string $theme = null,
     ): Number {
         return Number::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function password(
@@ -173,7 +172,7 @@ class PureField
         ?string $theme = null,
     ): Password {
         return Password::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function radioList(
@@ -183,7 +182,7 @@ class PureField
         ?string $theme = null,
     ): RadioList {
         return RadioList::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function range(
@@ -193,7 +192,7 @@ class PureField
         ?string $theme = null,
     ): Range {
         return Range::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function resetButton(
@@ -217,7 +216,7 @@ class PureField
         ?string $theme = null,
     ): Select {
         return Select::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function submitButton(
@@ -241,7 +240,7 @@ class PureField
         ?string $theme = null,
     ): Telephone {
         return Telephone::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function text(
@@ -251,7 +250,7 @@ class PureField
         ?string $theme = null,
     ): Text {
         return Text::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function textarea(
@@ -261,7 +260,7 @@ class PureField
         ?string $theme = null,
     ): Textarea {
         return Textarea::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function time(
@@ -271,7 +270,7 @@ class PureField
         ?string $theme = null,
     ): Time {
         return Time::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function url(
@@ -281,7 +280,7 @@ class PureField
         ?string $theme = null,
     ): Url {
         return Url::widget(config: $config, theme: $theme ?? static::DEFAULT_THEME)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public static function label(?string $content = null, array $config = [], ?string $theme = null): Label

--- a/src/PureField/FieldFactory.php
+++ b/src/PureField/FieldFactory.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form;
+namespace Yiisoft\Form\PureField;
 
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Button;
 use Yiisoft\Form\Field\ButtonGroup;
 use Yiisoft\Form\Field\Checkbox;
@@ -36,7 +35,7 @@ use Yiisoft\Form\Field\Url;
 /**
  * @psalm-import-type Errors from ErrorSummary
  */
-class PureFieldFactory
+class FieldFactory
 {
     final public function __construct(
         protected readonly ?string $defaultTheme = null,
@@ -66,7 +65,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Checkbox {
         return Checkbox::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function checkboxList(
@@ -76,7 +75,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): CheckboxList {
         return CheckboxList::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function date(
@@ -86,7 +85,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Date {
         return Date::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function dateTimeLocal(
@@ -96,7 +95,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): DateTimeLocal {
         return DateTimeLocal::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function email(
@@ -106,7 +105,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Email {
         return Email::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     /**
@@ -132,7 +131,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): File {
         return File::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function hidden(
@@ -142,7 +141,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Hidden {
         return Hidden::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function image(?string $url = null, array $config = [], ?string $theme = null): Image
@@ -163,7 +162,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Number {
         return Number::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function password(
@@ -173,7 +172,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Password {
         return Password::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function radioList(
@@ -183,7 +182,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): RadioList {
         return RadioList::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function range(
@@ -193,7 +192,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Range {
         return Range::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function resetButton(
@@ -217,7 +216,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Select {
         return Select::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function submitButton(
@@ -241,7 +240,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Telephone {
         return Telephone::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function text(
@@ -251,7 +250,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Text {
         return Text::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function textarea(
@@ -261,7 +260,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Textarea {
         return Textarea::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function time(
@@ -271,7 +270,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Time {
         return Time::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function url(
@@ -281,7 +280,7 @@ class PureFieldFactory
         ?string $theme = null,
     ): Url {
         return Url::widget(config: $config, theme: $theme ?? $this->defaultTheme)
-            ->inputData(new PureInputData($name, $value));
+            ->inputData(new InputData($name, $value));
     }
 
     final public function label(?string $content = null, array $config = [], ?string $theme = null): Label

--- a/src/PureField/InputData.php
+++ b/src/PureField/InputData.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form\Field\Base\InputData;
+namespace Yiisoft\Form\PureField;
 
-final class PureInputData implements InputDataInterface
+use Yiisoft\Form\Field\Base\InputData\InputDataInterface;
+
+final class InputData implements InputDataInterface
 {
     /**
      * @param string[] $validationErrors

--- a/src/Theme/Theme.php
+++ b/src/Theme/Theme.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form;
+namespace Yiisoft\Form\Theme;
 
 use Yiisoft\Form\Field\Base\EnrichFromValidationRules\EnrichFromValidationRulesInterface;
 use Yiisoft\Form\Field\Base\InputField;

--- a/src/Theme/ThemeContainer.php
+++ b/src/Theme/ThemeContainer.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form;
+namespace Yiisoft\Form\Theme;
 
 use Yiisoft\Form\Field\Base\BaseField;
 use Yiisoft\Form\Field\Base\InputData\InputDataInterface;
+use Yiisoft\Form\ValidationRulesEnricherInterface;
 
 use function array_key_exists;
 

--- a/src/Theme/ThemePath.php
+++ b/src/Theme/ThemePath.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form;
+namespace Yiisoft\Form\Theme;
 
 final class ThemePath
 {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -6,9 +6,9 @@ namespace Yiisoft\Form\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\PureField;
-use Yiisoft\Form\ThemeContainer;
 use Yiisoft\Form\Field\Hidden;
+use Yiisoft\Form\PureField\Field;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class ConfigTest extends TestCase
 {
@@ -49,7 +49,7 @@ final class ConfigTest extends TestCase
         $bootstrap = array_shift($bootstrapList);
         $bootstrap();
 
-        $input = PureField::hidden('key', 'x100');
+        $input = Field::hidden('key', 'x100');
 
         $this->assertSame(
             '<input type="hidden" id="TestId" name="key" value="x100">',

--- a/tests/Field/Base/BaseFieldTest.php
+++ b/tests/Field/Base/BaseFieldTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Form\Tests\Field\Base;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Tests\Support\StubBaseField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class BaseFieldTest extends TestCase
 {

--- a/tests/Field/Base/ButtonFieldTest.php
+++ b/tests/Field/Base/ButtonFieldTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Form\Tests\Field\Base;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Tests\Support\StubButtonField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\Button as ButtonTag;
 
 final class ButtonFieldTest extends TestCase

--- a/tests/Field/Base/DateTimeInputFieldTest.php
+++ b/tests/Field/Base/DateTimeInputFieldTest.php
@@ -7,10 +7,10 @@ namespace Yiisoft\Form\Tests\Field\Base;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StubDateTimeInputField;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class DateTimeInputFieldTest extends TestCase
 {
@@ -31,7 +31,7 @@ final class DateTimeInputFieldTest extends TestCase
                 <div>Need correct date</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'dt',
                     value: '',
                     label: 'Main date',
@@ -45,7 +45,7 @@ final class DateTimeInputFieldTest extends TestCase
                 <input type="datetime" class="valid" name="main" value>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', validationErrors: []),
+                new InputData(name: 'main', value: '', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -54,14 +54,14 @@ final class DateTimeInputFieldTest extends TestCase
                 <input type="datetime" name="main" value>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', validationErrors: []),
+                new InputData(name: 'main', value: '', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -275,7 +275,7 @@ final class DateTimeInputFieldTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = StubDateTimeInputField::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/Base/FieldContentTraitTest.php
+++ b/tests/Field/Base/FieldContentTraitTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Tests\Support\StringableObject;
 use Yiisoft\Form\Tests\Support\StubFieldContentTrait;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\P;
 use Yiisoft\Html\Tag\Span;
 

--- a/tests/Field/Base/InputFieldTest.php
+++ b/tests/Field/Base/InputFieldTest.php
@@ -6,10 +6,10 @@ namespace Yiisoft\Form\Tests\Field\Base;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StringableObject;
 use Yiisoft\Form\Tests\Support\StubInputField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class InputFieldTest extends TestCase
 {
@@ -180,7 +180,7 @@ final class InputFieldTest extends TestCase
     public function testPrepareValueWithInputData(): void
     {
         $result = StubInputField::widget()
-            ->inputData(new PureInputData(value: 9))
+            ->inputData(new InputData(value: 9))
             ->prepareValue(static fn ($value) => $value * 2)
             ->render();
 
@@ -204,7 +204,7 @@ final class InputFieldTest extends TestCase
         $this->assertNotSame($field, $field->addInputAttributes([]));
         $this->assertNotSame($field, $field->addInputClass());
         $this->assertNotSame($field, $field->inputClass());
-        $this->assertNotSame($field, $field->inputData(new PureInputData()));
+        $this->assertNotSame($field, $field->inputData(new InputData()));
         $this->assertNotSame($field, $field->name(null));
         $this->assertNotSame($field, $field->value(null));
         $this->assertNotSame($field, $field->prepareValue(null));

--- a/tests/Field/Base/PartsFieldTest.php
+++ b/tests/Field/Base/PartsFieldTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Yiisoft\Form\Tests\Support\StubPartsField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class PartsFieldTest extends TestCase
 {

--- a/tests/Field/Base/Placeholder/PlaceholderTraitTest.php
+++ b/tests/Field/Base/Placeholder/PlaceholderTraitTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Form\Tests\Field\Base\Placeholder;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Tests\Support\Placeholder\PlaceholderField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class PlaceholderTraitTest extends TestCase
 {

--- a/tests/Field/Base/ValidationClass/ValidationClassTraitTest.php
+++ b/tests/Field/Base/ValidationClass/ValidationClassTraitTest.php
@@ -6,9 +6,9 @@ namespace Yiisoft\Form\Tests\Field\Base\ValidationClass;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\ValidationClass\ValidationClassField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class ValidationClassTraitTest extends TestCase
 {
@@ -48,7 +48,7 @@ final class ValidationClassTraitTest extends TestCase
         $result = $field
             ->useContainer(false)
             ->template('{input}')
-            ->inputData(new PureInputData(validationErrors: $validationErrors))
+            ->inputData(new InputData(validationErrors: $validationErrors))
             ->render();
 
         $this->assertSame($expected, $result);

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Form\Tests\Field;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\ButtonGroup;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 final class ButtonGroupTest extends TestCase

--- a/tests/Field/ButtonTest.php
+++ b/tests/Field/ButtonTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Form\Tests\Field;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\Button;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class ButtonTest extends TestCase
 {

--- a/tests/Field/CheckboxListTest.php
+++ b/tests/Field/CheckboxListTest.php
@@ -8,9 +8,9 @@ use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\CheckboxList;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Widget\CheckboxList\CheckboxItem;
 
@@ -36,7 +36,7 @@ final class CheckboxListTest extends TestCase
                 <div>Color of box.</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'CheckboxListForm[color]',
                     label: 'Select one or more colors',
                     hint: 'Color of box.',
@@ -52,14 +52,14 @@ final class CheckboxListTest extends TestCase
                 </div>
                 </div>
                 HTML,
-                new PureInputData(name: 'color', validationErrors: []),
+                new InputData(name: 'color', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -438,7 +438,7 @@ final class CheckboxListTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', ['red']);
+        $inputData = new InputData('company', ['red']);
 
         $result = CheckboxList::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/CheckboxTest.php
+++ b/tests/Field/CheckboxTest.php
@@ -8,10 +8,10 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Checkbox;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StringableObject;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class CheckboxTest extends TestCase
 {
@@ -31,7 +31,7 @@ final class CheckboxTest extends TestCase
                 <div>If need red color.</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'CheckboxForm[red]',
                     value: '1',
                     label: 'Red color',
@@ -45,7 +45,7 @@ final class CheckboxTest extends TestCase
                 <input type="hidden" name="main" value="0"><input type="checkbox" class="valid" name="main" value="1" checked>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '1', validationErrors: []),
+                new InputData(name: 'main', value: '1', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -54,14 +54,14 @@ final class CheckboxTest extends TestCase
                 <input type="hidden" name="main" value="0"><input type="checkbox" name="main" value="1" checked>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '1', validationErrors: []),
+                new InputData(name: 'main', value: '1', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -75,7 +75,7 @@ final class CheckboxTest extends TestCase
 
     public function testFalseValue(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()->inputData($inputData)->render();
 
@@ -90,7 +90,7 @@ final class CheckboxTest extends TestCase
 
     public function testInputValue(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Red color');
+        $inputData = new InputData('test-name', label: 'Red color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -108,7 +108,7 @@ final class CheckboxTest extends TestCase
 
     public function testCheckedInputValue(): void
     {
-        $inputData = new PureInputData('test-name', 42, label: 'Your age 42?');
+        $inputData = new InputData('test-name', 42, label: 'Your age 42?');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -140,7 +140,7 @@ final class CheckboxTest extends TestCase
     #[DataProvider('dataUncheckValue')]
     public function testUncheckValue(string $expectedInput, mixed $uncheckValue): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -157,7 +157,7 @@ final class CheckboxTest extends TestCase
 
     public function testNotEnclosedByLabel(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -176,7 +176,7 @@ final class CheckboxTest extends TestCase
 
     public function testAllLabels(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -197,7 +197,7 @@ final class CheckboxTest extends TestCase
 
     public function testWithoutInputLabel(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -217,7 +217,7 @@ final class CheckboxTest extends TestCase
 
     public function testBothLabelsWithNotEnclosedByLabel(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -238,7 +238,7 @@ final class CheckboxTest extends TestCase
 
     public function testInputLabelEncode(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -256,7 +256,7 @@ final class CheckboxTest extends TestCase
 
     public function testInputLabelNotEncode(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -275,7 +275,7 @@ final class CheckboxTest extends TestCase
 
     public function testInputLabelEncodeNotEnclosedByLabel(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -295,7 +295,7 @@ final class CheckboxTest extends TestCase
 
     public function testInputLabelNotEncodeNotEnclosedByLabel(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -316,7 +316,7 @@ final class CheckboxTest extends TestCase
 
     public function testAddInputLabelAttributes(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -335,7 +335,7 @@ final class CheckboxTest extends TestCase
 
     public function testInputLabelAttributes(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -363,7 +363,7 @@ final class CheckboxTest extends TestCase
     #[DataProvider('dataInputLabelId')]
     public function testInputLabelId(string $expectedId, ?string $id): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -396,7 +396,7 @@ final class CheckboxTest extends TestCase
     #[DataProvider('dataAddInputLabelClass')]
     public function testAddInputLabelClass(string $expectedClassAttribute, array $class): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -425,7 +425,7 @@ final class CheckboxTest extends TestCase
     #[DataProvider('dataAddInputLabelNewClass')]
     public function testAddInputLabelNewClass(string $expectedClassAttribute, ?string $class): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -459,7 +459,7 @@ final class CheckboxTest extends TestCase
     #[DataProvider('dataInputLabelClass')]
     public function testInputLabelClass(string $expectedClassAttribute, array $class): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -478,7 +478,7 @@ final class CheckboxTest extends TestCase
 
     public function testDisabled(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -515,7 +515,7 @@ final class CheckboxTest extends TestCase
 
     public function testAriaLabel(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -534,7 +534,7 @@ final class CheckboxTest extends TestCase
 
     public function testAutofocus(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -553,7 +553,7 @@ final class CheckboxTest extends TestCase
 
     public function testTabIndex(): void
     {
-        $inputData = new PureInputData('test-name', label: 'Blue color');
+        $inputData = new InputData('test-name', label: 'Blue color');
 
         $result = Checkbox::widget()
             ->inputData($inputData)
@@ -581,7 +581,7 @@ final class CheckboxTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Checkbox::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/DateTest.php
+++ b/tests/Field/DateTest.php
@@ -6,9 +6,9 @@ namespace Yiisoft\Form\Tests\Field;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Date;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class DateTest extends TestCase
 {
@@ -20,7 +20,7 @@ final class DateTest extends TestCase
 
     public function testBase(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'DateForm[birthday]',
             value: '1996-12-19',
             label: 'Your birthday',

--- a/tests/Field/DateTimeLocalTest.php
+++ b/tests/Field/DateTimeLocalTest.php
@@ -6,9 +6,9 @@ namespace Yiisoft\Form\Tests\Field;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\DateTimeLocal;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class DateTimeLocalTest extends TestCase
 {
@@ -20,7 +20,7 @@ final class DateTimeLocalTest extends TestCase
 
     public function testBase(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'partyDate',
             value: '2017-06-01T08:30',
             label: 'Date of party',

--- a/tests/Field/EmailTest.php
+++ b/tests/Field/EmailTest.php
@@ -7,10 +7,10 @@ namespace Yiisoft\Form\Tests\Field;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Email;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class EmailTest extends TestCase
 {
@@ -31,7 +31,7 @@ final class EmailTest extends TestCase
                 <div>Email for notifications.</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'EmailForm[main]',
                     value: '',
                     label: 'Main email',
@@ -45,7 +45,7 @@ final class EmailTest extends TestCase
                 <input type="email" class="valid" name="main" value>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', validationErrors: []),
+                new InputData(name: 'main', value: '', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -54,7 +54,7 @@ final class EmailTest extends TestCase
                 <input type="email" name="main" value>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', validationErrors: []),
+                new InputData(name: 'main', value: '', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
             'placeholder' => [
@@ -63,13 +63,13 @@ final class EmailTest extends TestCase
                 <input type="email" name="main" value placeholder="test">
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', placeholder: 'test'),
+                new InputData(name: 'main', value: '', placeholder: 'test'),
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -322,7 +322,7 @@ final class EmailTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Email::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/ErrorSummaryTest.php
+++ b/tests/Field/ErrorSummaryTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\ErrorSummary;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class ErrorSummaryTest extends TestCase
 {

--- a/tests/Field/FieldsetTest.php
+++ b/tests/Field/FieldsetTest.php
@@ -6,8 +6,8 @@ namespace Yiisoft\Form\Tests\Field;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\Fieldset;
-use Yiisoft\Form\PureField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\Field;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\Legend;
 
 final class FieldsetTest extends TestCase
@@ -22,9 +22,9 @@ final class FieldsetTest extends TestCase
     {
         $result = Fieldset::widget()->begin()
             . "\n"
-            . PureField::text('firstName', '')->useContainer(false)
+            . Field::text('firstName', '')->useContainer(false)
             . "\n"
-            . PureField::text('lastName', '')->useContainer(false)
+            . Field::text('lastName', '')->useContainer(false)
             . "\n"
             . Fieldset::end();
 
@@ -45,9 +45,9 @@ final class FieldsetTest extends TestCase
     {
         $result = Fieldset::widget()
             ->content(
-                PureField::text('firstName', '')->useContainer(false),
+                Field::text('firstName', '')->useContainer(false),
                 "\n",
-                PureField::text('lastName', '')->useContainer(false),
+                Field::text('lastName', '')->useContainer(false),
             )
             ->render();
 

--- a/tests/Field/FileTest.php
+++ b/tests/Field/FileTest.php
@@ -6,10 +6,10 @@ namespace Yiisoft\Form\Tests\Field;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\File;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class FileTest extends TestCase
 {
@@ -29,7 +29,7 @@ final class FileTest extends TestCase
                 <input type="file" id="id-test" name="avatar">
                 </div>
                 HTML,
-                new PureInputData(name: 'avatar', id: 'id-test', label: 'Avatar'),
+                new InputData(name: 'avatar', id: 'id-test', label: 'Avatar'),
             ],
             'input-valid-class' => [
                 <<<HTML
@@ -37,7 +37,7 @@ final class FileTest extends TestCase
                 <input type="file" class="valid" name="avatar">
                 </div>
                 HTML,
-                new PureInputData(name: 'avatar', value: '', validationErrors: []),
+                new InputData(name: 'avatar', value: '', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -46,14 +46,14 @@ final class FileTest extends TestCase
                 <input type="file" name="avatar">
                 </div>
                 HTML,
-                new PureInputData(name: 'avatar', value: '', validationErrors: []),
+                new InputData(name: 'avatar', value: '', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -301,7 +301,7 @@ final class FileTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = File::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/HiddenTest.php
+++ b/tests/Field/HiddenTest.php
@@ -6,9 +6,9 @@ namespace Yiisoft\Form\Tests\Field;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Hidden;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class HiddenTest extends TestCase
 {
@@ -20,7 +20,7 @@ final class HiddenTest extends TestCase
 
     public function testBase(): void
     {
-        $inputData = new PureInputData('key', 'x100', id: 'hiddenform-key');
+        $inputData = new InputData('key', 'x100', id: 'hiddenform-key');
 
         $field = Hidden::widget()->inputData($inputData);
 

--- a/tests/Field/ImageTest.php
+++ b/tests/Field/ImageTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\Image;
 use Yiisoft\Form\Tests\Support\StringableObject;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class ImageTest extends TestCase
 {

--- a/tests/Field/NumberTest.php
+++ b/tests/Field/NumberTest.php
@@ -7,11 +7,11 @@ namespace Yiisoft\Form\Tests\Field;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Number;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StringableObject;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class NumberTest extends TestCase
 {
@@ -32,7 +32,7 @@ final class NumberTest extends TestCase
                 <div>Full years.</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'NumberForm[age]',
                     value: 42,
                     hint: 'Full years.',
@@ -46,7 +46,7 @@ final class NumberTest extends TestCase
                 <input type="number" class="valid" name="main" value="1">
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: 1, validationErrors: []),
+                new InputData(name: 'main', value: 1, validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -55,7 +55,7 @@ final class NumberTest extends TestCase
                 <input type="number" name="main" value="1">
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: 1, validationErrors: []),
+                new InputData(name: 'main', value: 1, validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
             'placeholder' => [
@@ -64,13 +64,13 @@ final class NumberTest extends TestCase
                 <input type="number" name="main" value="1" placeholder="test">
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: 1, placeholder: 'test'),
+                new InputData(name: 'main', value: 1, placeholder: 'test'),
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -362,7 +362,7 @@ final class NumberTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company');
+        $inputData = new InputData('company');
 
         $result = Number::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/Part/ErrorTest.php
+++ b/tests/Field/Part/ErrorTest.php
@@ -7,10 +7,10 @@ namespace Yiisoft\Form\Tests\Field\Part;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Base\InputData\InputDataInterface;
 use Yiisoft\Form\Field\Part\Error;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class ErrorTest extends TestCase
 {
@@ -22,7 +22,7 @@ final class ErrorTest extends TestCase
 
     public function testBase(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.', 'Value is bad.'],
         );
 
@@ -52,7 +52,7 @@ final class ErrorTest extends TestCase
 
     public function testWithoutError(): void
     {
-        $inputData = new PureInputData();
+        $inputData = new InputData();
 
         $result = Error::widget()->inputData($inputData)->render();
 
@@ -61,7 +61,7 @@ final class ErrorTest extends TestCase
 
     public function testCustomTag(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -78,13 +78,13 @@ final class ErrorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Tag name cannot be empty.');
         Error::widget()
-            ->inputData(new PureInputData())
+            ->inputData(new InputData())
             ->tag('');
     }
 
     public function testAddAttributes(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -99,7 +99,7 @@ final class ErrorTest extends TestCase
 
     public function testAttributes(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -123,7 +123,7 @@ final class ErrorTest extends TestCase
     #[DataProvider('dataId')]
     public function testId(string $expectedId, ?string $id): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -154,7 +154,7 @@ final class ErrorTest extends TestCase
     #[DataProvider('dataAddClass')]
     public function testAddClass(string $expectedClassAttribute, array $class): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -181,7 +181,7 @@ final class ErrorTest extends TestCase
     #[DataProvider('dataAddNewClass')]
     public function testAddNewClass(string $expectedClassAttribute, ?string $class): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -213,7 +213,7 @@ final class ErrorTest extends TestCase
     #[DataProvider('dataClass')]
     public function testClass(string $expectedClassAttribute, array $class): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -230,7 +230,7 @@ final class ErrorTest extends TestCase
 
     public function testEncode(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -244,7 +244,7 @@ final class ErrorTest extends TestCase
 
     public function testWithoutEncode(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -259,7 +259,7 @@ final class ErrorTest extends TestCase
 
     public function testCustomMessage(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             validationErrors: ['Value cannot be blank.'],
         );
 
@@ -273,7 +273,7 @@ final class ErrorTest extends TestCase
 
     public function testCustomMessageWithoutError(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             label: 'Age',
             validationErrors: [],
         );
@@ -288,7 +288,7 @@ final class ErrorTest extends TestCase
 
     public function testMessageCallback(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             label: 'Name',
             validationErrors: ['Value cannot be blank.'],
         );
@@ -305,7 +305,7 @@ final class ErrorTest extends TestCase
 
     public function testMessageCallbackWithCustomMessage(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             label: 'Name',
             validationErrors: ['Value cannot be blank.'],
         );
@@ -323,7 +323,7 @@ final class ErrorTest extends TestCase
 
     public function testMessageCallbackWithMessageAndWithoutError(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             label: 'Age',
             validationErrors: [],
         );

--- a/tests/Field/Part/HintTest.php
+++ b/tests/Field/Part/HintTest.php
@@ -7,9 +7,9 @@ namespace Yiisoft\Form\Tests\Field\Part;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Part\Hint;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class HintTest extends TestCase
 {
@@ -21,7 +21,7 @@ final class HintTest extends TestCase
 
     public function testBase(): void
     {
-        $inputData = new PureInputData(hint: 'Write your name.');
+        $inputData = new InputData(hint: 'Write your name.');
 
         $result = Hint::widget()->inputData($inputData)->render();
 
@@ -176,7 +176,7 @@ final class HintTest extends TestCase
 
     public function testCustomContent(): void
     {
-        $inputData = new PureInputData(hint: 'Write your name.');
+        $inputData = new InputData(hint: 'Write your name.');
 
         $result = Hint::widget()
             ->inputData($inputData)
@@ -188,7 +188,7 @@ final class HintTest extends TestCase
 
     public function testEmptyContent(): void
     {
-        $inputData = new PureInputData(hint: 'Write your name.');
+        $inputData = new InputData(hint: 'Write your name.');
 
         $result = Hint::widget()
             ->inputData($inputData)
@@ -200,7 +200,7 @@ final class HintTest extends TestCase
 
     public function testEncode(): void
     {
-        $inputData = new PureInputData(hint: 'Write your name.');
+        $inputData = new InputData(hint: 'Write your name.');
 
         $result = Hint::widget()
             ->inputData($inputData)
@@ -212,7 +212,7 @@ final class HintTest extends TestCase
 
     public function testWithoutEncode(): void
     {
-        $inputData = new PureInputData(hint: 'Write your name.');
+        $inputData = new InputData(hint: 'Write your name.');
 
         $result = Hint::widget()
             ->inputData($inputData)
@@ -226,7 +226,7 @@ final class HintTest extends TestCase
     public function testImmutability(): void
     {
         $widget = Hint::widget();
-        $this->assertNotSame($widget, $widget->inputData(new PureInputData()));
+        $this->assertNotSame($widget, $widget->inputData(new InputData()));
         $this->assertNotSame($widget, $widget->tag('b'));
         $this->assertNotSame($widget, $widget->attributes([]));
         $this->assertNotSame($widget, $widget->addAttributes([]));

--- a/tests/Field/Part/LabelTest.php
+++ b/tests/Field/Part/LabelTest.php
@@ -6,10 +6,10 @@ namespace Yiisoft\Form\Tests\Field\Part;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Part\Label;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StringableObject;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class LabelTest extends TestCase
 {
@@ -21,7 +21,7 @@ final class LabelTest extends TestCase
 
     public function testBase(): void
     {
-        $inputData = new PureInputData(label: 'Name', id: 'id-test');
+        $inputData = new InputData(label: 'Name', id: 'id-test');
 
         $result = Label::widget()->inputData($inputData)->render();
 
@@ -162,7 +162,7 @@ final class LabelTest extends TestCase
 
     public function customFor(): void
     {
-        $inputData = new PureInputData(label: 'Name', id: 'id-test');
+        $inputData = new InputData(label: 'Name', id: 'id-test');
 
         $result = Label::widget()
             ->inputData($inputData)
@@ -184,7 +184,7 @@ final class LabelTest extends TestCase
 
     public function testCustomForWithDoNotUseInputId(): void
     {
-        $inputData = new PureInputData(label: 'Name', id: 'id-test');
+        $inputData = new InputData(label: 'Name', id: 'id-test');
 
         $result = Label::widget()
             ->inputData($inputData)
@@ -197,7 +197,7 @@ final class LabelTest extends TestCase
 
     public function testCustomContent(): void
     {
-        $inputData = new PureInputData(label: 'Name', id: 'labelform-name');
+        $inputData = new InputData(label: 'Name', id: 'labelform-name');
 
         $result = Label::widget()
             ->inputData($inputData)
@@ -209,7 +209,7 @@ final class LabelTest extends TestCase
 
     public function testEmptyContent(): void
     {
-        $inputData = new PureInputData(label: 'Name', id: 'id-test');
+        $inputData = new InputData(label: 'Name', id: 'id-test');
 
         $result = Label::widget()
             ->inputData($inputData)
@@ -221,7 +221,7 @@ final class LabelTest extends TestCase
 
     public function testContentAsStringableObject(): void
     {
-        $inputData = new PureInputData(label: 'Name');
+        $inputData = new InputData(label: 'Name');
 
         $result = Label::widget()
             ->inputData($inputData)
@@ -233,7 +233,7 @@ final class LabelTest extends TestCase
 
     public function testEncode(): void
     {
-        $inputData = new PureInputData(label: 'Name');
+        $inputData = new InputData(label: 'Name');
 
         $result = Label::widget()
             ->inputData($inputData)
@@ -245,7 +245,7 @@ final class LabelTest extends TestCase
 
     public function testWithoutEncode(): void
     {
-        $inputData = new PureInputData(label: 'Name', id: 'labelform-name');
+        $inputData = new InputData(label: 'Name', id: 'labelform-name');
 
         $result = Label::widget()
             ->inputData($inputData)

--- a/tests/Field/PasswordTest.php
+++ b/tests/Field/PasswordTest.php
@@ -7,10 +7,10 @@ namespace Yiisoft\Form\Tests\Field;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Password;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class PasswordTest extends TestCase
 {
@@ -31,7 +31,7 @@ final class PasswordTest extends TestCase
                 <div>Enter your old password.</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'PasswordForm[old]',
                     value: '',
                     label: 'Old password',
@@ -45,7 +45,7 @@ final class PasswordTest extends TestCase
                 <input type="password" class="valid" name="main" value>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', validationErrors: []),
+                new InputData(name: 'main', value: '', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -54,7 +54,7 @@ final class PasswordTest extends TestCase
                 <input type="password" name="main" value>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', validationErrors: []),
+                new InputData(name: 'main', value: '', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
             'placeholder' => [
@@ -63,13 +63,13 @@ final class PasswordTest extends TestCase
                 <input type="password" name="main" value placeholder="test">
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', placeholder: 'test'),
+                new InputData(name: 'main', value: '', placeholder: 'test'),
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -295,7 +295,7 @@ final class PasswordTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Password::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/RadioListTest.php
+++ b/tests/Field/RadioListTest.php
@@ -8,10 +8,10 @@ use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\RadioList;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StringableObject;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Widget\RadioList\RadioItem;
 
@@ -37,7 +37,7 @@ final class RadioListTest extends TestCase
                 <div>Color of box.</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'RadioListForm[color]',
                     label: 'Select color',
                     hint: 'Color of box.',
@@ -53,14 +53,14 @@ final class RadioListTest extends TestCase
                 </div>
                 </div>
                 HTML,
-                new PureInputData(name: 'color', validationErrors: []),
+                new InputData(name: 'color', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -636,7 +636,7 @@ final class RadioListTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('number', 2);
+        $inputData = new InputData('number', 2);
 
         $result = RadioList::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/RangeTest.php
+++ b/tests/Field/RangeTest.php
@@ -7,11 +7,11 @@ namespace Yiisoft\Form\Tests\Field;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Range;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StringableObject;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class RangeTest extends TestCase
 {
@@ -31,7 +31,7 @@ final class RangeTest extends TestCase
                 <input type="range" id="rangeform-volume" name="RangeForm[volume]" value="23" min="1" max="100">
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'RangeForm[volume]',
                     value: 23,
                     label: 'Volume level',
@@ -44,7 +44,7 @@ final class RangeTest extends TestCase
                 <input type="range" class="valid" name="main" min="1" max="100">
                 </div>
                 HTML,
-                new PureInputData(name: 'main', validationErrors: []),
+                new InputData(name: 'main', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -53,14 +53,14 @@ final class RangeTest extends TestCase
                 <input type="range" name="main" min="1" max="100">
                 </div>
                 HTML,
-                new PureInputData(name: 'main', validationErrors: []),
+                new InputData(name: 'main', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -422,7 +422,7 @@ HTML_WRAP;
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Range::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/ResetButtonTest.php
+++ b/tests/Field/ResetButtonTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Form\Tests\Field;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\ResetButton;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class ResetButtonTest extends TestCase
 {

--- a/tests/Field/SelectTest.php
+++ b/tests/Field/SelectTest.php
@@ -8,10 +8,10 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Select;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\Optgroup;
 use Yiisoft\Html\Tag\Option;
 
@@ -36,7 +36,7 @@ final class SelectTest extends TestCase
                 </select>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'SelectForm[number]',
                     label: 'Select number',
                     id: 'selectform-number',
@@ -51,7 +51,7 @@ final class SelectTest extends TestCase
                 </select>
                 </div>
                 HTML,
-                new PureInputData(name: 'number', validationErrors: []),
+                new InputData(name: 'number', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -63,14 +63,14 @@ final class SelectTest extends TestCase
                 </select>
                 </div>
                 HTML,
-                new PureInputData(name: 'number', validationErrors: []),
+                new InputData(name: 'number', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -115,7 +115,7 @@ final class SelectTest extends TestCase
 
     public function testSelectedMultiple(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'SelectForm[letters]',
             value: ['A', 'C'],
             label: 'Select letters',
@@ -671,7 +671,7 @@ final class SelectTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Select::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/SubmitButtonTest.php
+++ b/tests/Field/SubmitButtonTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Form\Tests\Field;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\SubmitButton;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\Button;
 
 final class SubmitButtonTest extends TestCase

--- a/tests/Field/TelephoneTest.php
+++ b/tests/Field/TelephoneTest.php
@@ -7,10 +7,10 @@ namespace Yiisoft\Form\Tests\Field;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Telephone;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class TelephoneTest extends TestCase
 {
@@ -31,7 +31,7 @@ final class TelephoneTest extends TestCase
                 <div>Enter your phone.</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'TelephoneForm[number]',
                     value: '',
                     id: 'telephoneform-number',
@@ -45,7 +45,7 @@ final class TelephoneTest extends TestCase
                 <input type="tel" class="valid" name="main" value>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', validationErrors: []),
+                new InputData(name: 'main', value: '', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -54,7 +54,7 @@ final class TelephoneTest extends TestCase
                 <input type="tel" name="main" value>
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', validationErrors: []),
+                new InputData(name: 'main', value: '', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
             'placeholder' => [
@@ -63,13 +63,13 @@ final class TelephoneTest extends TestCase
                 <input type="tel" name="main" value placeholder="test">
                 </div>
                 HTML,
-                new PureInputData(name: 'main', value: '', placeholder: 'test'),
+                new InputData(name: 'main', value: '', placeholder: 'test'),
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -295,7 +295,7 @@ final class TelephoneTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Telephone::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/TextTest.php
+++ b/tests/Field/TextTest.php
@@ -6,9 +6,9 @@ namespace Yiisoft\Form\Tests\Field;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Text;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class TextTest extends TestCase
 {
@@ -20,7 +20,7 @@ final class TextTest extends TestCase
 
     public function testBase(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'TextForm[name]',
             value: '',
             id: 'textform-name',
@@ -72,7 +72,7 @@ final class TextTest extends TestCase
 
     public function testCustomNameAfterInputData(): void
     {
-        $inputData = new PureInputData('test', '');
+        $inputData = new InputData('test', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -90,7 +90,7 @@ final class TextTest extends TestCase
 
     public function testCustomNameBeforeInputData(): void
     {
-        $inputData = new PureInputData('test', '');
+        $inputData = new InputData('test', '');
 
         $result = Text::widget()
             ->name('the-name')
@@ -108,7 +108,7 @@ final class TextTest extends TestCase
 
     public function testCustomValueAfterInputData(): void
     {
-        $inputData = new PureInputData('test', '42');
+        $inputData = new InputData('test', '42');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -126,7 +126,7 @@ final class TextTest extends TestCase
 
     public function testCustomValueBeforeInputData(): void
     {
-        $inputData = new PureInputData('test', '42');
+        $inputData = new InputData('test', '42');
 
         $result = Text::widget()
             ->value('7')
@@ -153,7 +153,7 @@ final class TextTest extends TestCase
 
     public function testWithoutContainer(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             validationErrors: [],
@@ -169,7 +169,7 @@ final class TextTest extends TestCase
 
     public function testCustomContainerTag(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             validationErrors: [],
@@ -200,7 +200,7 @@ final class TextTest extends TestCase
 
     public function testContainerAttributes(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             validationErrors: [],
@@ -222,7 +222,7 @@ final class TextTest extends TestCase
 
     public function testCustomTemplate(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'TextForm[name]',
             value: '',
             id: 'textform-name',
@@ -253,7 +253,7 @@ final class TextTest extends TestCase
 
     public function testCustomInputId(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             label: 'Job',
@@ -277,7 +277,7 @@ final class TextTest extends TestCase
 
     public function testDoNotSetInputId(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             label: 'Job',
@@ -301,7 +301,7 @@ final class TextTest extends TestCase
 
     public function testCustomLabelConfig(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             id: 'job-id',
@@ -329,7 +329,7 @@ final class TextTest extends TestCase
 
     public function testCustomLabel(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             label: 'Job',
@@ -353,7 +353,7 @@ final class TextTest extends TestCase
 
     public function testCustomHintConfig(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'TextForm[name]',
             value: '',
             hint: 'Input your full name.',
@@ -379,7 +379,7 @@ final class TextTest extends TestCase
 
     public function testCustomHint(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'TextForm[name]',
             value: '',
             hint: 'Input your full name.',
@@ -402,7 +402,7 @@ final class TextTest extends TestCase
 
     public function testCustomErrorConfig(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'test',
             validationErrors: ['Value cannot be blank.'],
         );
@@ -427,7 +427,7 @@ final class TextTest extends TestCase
 
     public function testOverridePlaceholder(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'TextForm[name]',
             value: '',
             placeholder: 'Your name',
@@ -449,7 +449,7 @@ final class TextTest extends TestCase
 
     public function testDoNotSetPlaceholder(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'TextForm[name]',
             value: '',
             placeholder: 'Your name',
@@ -471,7 +471,7 @@ final class TextTest extends TestCase
 
     public function testAddInputAttributes(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -489,7 +489,7 @@ final class TextTest extends TestCase
 
     public function testInputAttributesOverridePlaceholderFromForm(): void
     {
-        $inputData = new PureInputData('job', '', placeholder: 'Your name');
+        $inputData = new InputData('job', '', placeholder: 'Your name');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -507,7 +507,7 @@ final class TextTest extends TestCase
 
     public function testInputAttributesOverrideIdFromForm(): void
     {
-        $inputData = new PureInputData('name', '', id: 'test-id', label: 'Name');
+        $inputData = new InputData('name', '', id: 'test-id', label: 'Name');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -526,7 +526,7 @@ final class TextTest extends TestCase
 
     public function testInputIdOverrideIdFromAttributes(): void
     {
-        $inputData = new PureInputData('name', '', id: 'test-id', label: 'Name');
+        $inputData = new InputData('name', '', id: 'test-id', label: 'Name');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -546,7 +546,7 @@ final class TextTest extends TestCase
 
     public function testDirname(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -564,7 +564,7 @@ final class TextTest extends TestCase
 
     public function testMaxlength(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -582,7 +582,7 @@ final class TextTest extends TestCase
 
     public function testMinlength(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -600,7 +600,7 @@ final class TextTest extends TestCase
 
     public function testPattern(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -618,7 +618,7 @@ final class TextTest extends TestCase
 
     public function testSize(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -636,7 +636,7 @@ final class TextTest extends TestCase
 
     public function testReadonly(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -653,7 +653,7 @@ final class TextTest extends TestCase
 
     public function testRequired(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -670,7 +670,7 @@ final class TextTest extends TestCase
 
     public function testDisabled(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -687,7 +687,7 @@ final class TextTest extends TestCase
 
     public function testAriaDescribedBy(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -704,7 +704,7 @@ final class TextTest extends TestCase
 
     public function testAriaLabel(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -721,7 +721,7 @@ final class TextTest extends TestCase
 
     public function testAutofocus(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -738,7 +738,7 @@ final class TextTest extends TestCase
 
     public function testTabIndex(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->inputData($inputData)
@@ -755,7 +755,7 @@ final class TextTest extends TestCase
 
     public function testValidationClassForNonValidatedForm(): void
     {
-        $inputData = new PureInputData('job', '');
+        $inputData = new InputData('job', '');
 
         $result = Text::widget()
             ->invalidClass('invalid')
@@ -774,7 +774,7 @@ final class TextTest extends TestCase
 
     public function testInvalidClass(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'company',
             value: '',
             validationErrors: ['Value cannot be blank.'],
@@ -798,7 +798,7 @@ final class TextTest extends TestCase
 
     public function testValidClass(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             validationErrors: [],
@@ -821,7 +821,7 @@ final class TextTest extends TestCase
 
     public function testInputInvalidClass(): void
     {
-        $inputData = new PureInputData('company', '', validationErrors: ['Value cannot be blank.']);
+        $inputData = new InputData('company', '', validationErrors: ['Value cannot be blank.']);
 
         $result = Text::widget()
             ->inputInvalidClass('invalid')
@@ -841,7 +841,7 @@ final class TextTest extends TestCase
 
     public function testInputValidClass(): void
     {
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             name: 'job',
             value: '',
             validationErrors: [],
@@ -864,7 +864,7 @@ final class TextTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Text::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/TextareaTest.php
+++ b/tests/Field/TextareaTest.php
@@ -7,10 +7,10 @@ namespace Yiisoft\Form\Tests\Field;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Textarea;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class TextareaTest extends TestCase
 {
@@ -30,7 +30,7 @@ final class TextareaTest extends TestCase
                 <textarea id="test-id" name="desc"></textarea>
                 </div>
                 HTML,
-                new PureInputData('desc', id: 'test-id', label: 'Description'),
+                new InputData('desc', id: 'test-id', label: 'Description'),
             ],
             'input-valid-class' => [
                 <<<HTML
@@ -38,7 +38,7 @@ final class TextareaTest extends TestCase
                 <textarea class="valid" name="desc"></textarea>
                 </div>
                 HTML,
-                new PureInputData(name: 'desc', validationErrors: []),
+                new InputData(name: 'desc', validationErrors: []),
                 ['inputValidClass' => 'valid', 'inputInvalidClass' => 'invalid'],
             ],
             'container-valid-class' => [
@@ -47,7 +47,7 @@ final class TextareaTest extends TestCase
                 <textarea name="desc"></textarea>
                 </div>
                 HTML,
-                new PureInputData(name: 'desc', validationErrors: []),
+                new InputData(name: 'desc', validationErrors: []),
                 ['validClass' => 'valid', 'invalidClass' => 'invalid'],
             ],
             'placeholder' => [
@@ -56,13 +56,13 @@ final class TextareaTest extends TestCase
                 <textarea name="desc" placeholder="test"></textarea>
                 </div>
                 HTML,
-                new PureInputData(name: 'desc', placeholder: 'test'),
+                new InputData(name: 'desc', placeholder: 'test'),
             ],
         ];
     }
 
     #[DataProvider('dataBase')]
-    public function testTextarea(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testTextarea(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -318,7 +318,7 @@ final class TextareaTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Textarea::widget()
             ->invalidClass('invalidWrap')

--- a/tests/Field/TimeTest.php
+++ b/tests/Field/TimeTest.php
@@ -9,7 +9,7 @@ namespace Yiisoft\Form\Tests\Field;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\Time;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class TimeTest extends TestCase
 {

--- a/tests/Field/UrlTest.php
+++ b/tests/Field/UrlTest.php
@@ -7,10 +7,10 @@ namespace Yiisoft\Form\Tests\Field;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Url;
+use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class UrlTest extends TestCase
 {
@@ -31,7 +31,7 @@ final class UrlTest extends TestCase
                 <div>Enter your site URL.</div>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'UrlForm[site]',
                     value: '',
                     label: 'Your site',
@@ -45,7 +45,7 @@ final class UrlTest extends TestCase
                 <input type="url" class="valid" name="site" value>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'site',
                     value: '',
                     validationErrors: [],
@@ -58,7 +58,7 @@ final class UrlTest extends TestCase
                 <input type="url" name="site" value>
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'site',
                     value: '',
                     validationErrors: [],
@@ -71,7 +71,7 @@ final class UrlTest extends TestCase
                 <input type="url" name="site" value placeholder="test">
                 </div>
                 HTML,
-                new PureInputData(
+                new InputData(
                     name: 'site',
                     value: '',
                     placeholder: 'test'
@@ -81,7 +81,7 @@ final class UrlTest extends TestCase
     }
 
     #[DataProvider('dataBase')]
-    public function testBase(string $expected, PureInputData $inputData, array $theme = []): void
+    public function testBase(string $expected, InputData $inputData, array $theme = []): void
     {
         ThemeContainer::initialize(
             configs: ['default' => $theme],
@@ -329,7 +329,7 @@ final class UrlTest extends TestCase
 
     public function testInvalidClassesWithCustomError(): void
     {
-        $inputData = new PureInputData('company', '');
+        $inputData = new InputData('company', '');
 
         $result = Url::widget()
             ->invalidClass('invalidWrap')

--- a/tests/PureField/FieldFactoryTest.php
+++ b/tests/PureField/FieldFactoryTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form\Tests;
+namespace Yiisoft\Form\Tests\PureField;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\PureFieldFactory;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\FieldFactory;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\Button;
 
-final class PureFieldFactoryTest extends TestCase
+final class FieldFactoryTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -19,7 +19,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testButton(): void
     {
-        $html = (new PureFieldFactory())->button()->render();
+        $html = (new FieldFactory())->button()->render();
 
         $expected = <<<HTML
             <div>
@@ -32,7 +32,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testButtonWithContent(): void
     {
-        $html = (new PureFieldFactory())->button('Start')->render();
+        $html = (new FieldFactory())->button('Start')->render();
 
         $expected = <<<HTML
             <div>
@@ -51,7 +51,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->button(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->button(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -64,7 +64,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testButtonGroup(): void
     {
-        $html = (new PureFieldFactory())->buttonGroup()->buttons(Button::tag())->render();
+        $html = (new FieldFactory())->buttonGroup()->buttons(Button::tag())->render();
 
         $expected = <<<HTML
             <div>
@@ -83,7 +83,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->buttonGroup(theme: 'test')->buttons(Button::tag())->render();
+        $html = (new FieldFactory('default'))->buttonGroup(theme: 'test')->buttons(Button::tag())->render();
 
         $expected = <<<HTML
             <span>
@@ -96,7 +96,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testCheckbox(): void
     {
-        $html = (new PureFieldFactory())->checkbox()->render();
+        $html = (new FieldFactory())->checkbox()->render();
 
         $expected = <<<HTML
             <div>
@@ -115,7 +115,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->checkbox(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->checkbox(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -128,7 +128,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testCheckboxList(): void
     {
-        $html = (new PureFieldFactory())->checkboxList()
+        $html = (new FieldFactory())->checkboxList()
             ->name('test')
             ->itemsFromValues(['a', 'b'])
             ->render();
@@ -153,7 +153,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->checkboxList(theme: 'test')
+        $html = (new FieldFactory('default'))->checkboxList(theme: 'test')
             ->name('test')
             ->itemsFromValues(['a', 'b'])
             ->render();
@@ -172,7 +172,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testDate(): void
     {
-        $html = (new PureFieldFactory())->date()->render();
+        $html = (new FieldFactory())->date()->render();
 
         $expected = <<<HTML
             <div>
@@ -191,7 +191,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->date(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->date(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -204,7 +204,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testDateTimeLocal(): void
     {
-        $html = (new PureFieldFactory())->dateTimeLocal()->render();
+        $html = (new FieldFactory())->dateTimeLocal()->render();
 
         $expected = <<<HTML
             <div>
@@ -223,7 +223,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->dateTimeLocal(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->dateTimeLocal(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -236,7 +236,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testEmail(): void
     {
-        $html = (new PureFieldFactory())->email()->render();
+        $html = (new FieldFactory())->email()->render();
 
         $expected = <<<HTML
             <div>
@@ -255,7 +255,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->email(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->email(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -268,7 +268,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testErrorSummary(): void
     {
-        $html = (new PureFieldFactory())->errorSummary(['key' => ['e1', 'e2']])->render();
+        $html = (new FieldFactory())->errorSummary(['key' => ['e1', 'e2']])->render();
 
         $expected = <<<HTML
             <div>
@@ -290,7 +290,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->errorSummary(['key' => ['e1', 'e2']], theme: 'test')->render();
+        $html = (new FieldFactory('default'))->errorSummary(['key' => ['e1', 'e2']], theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -306,7 +306,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testFieldset(): void
     {
-        $html = (new PureFieldFactory())->fieldset()->render();
+        $html = (new FieldFactory())->fieldset()->render();
 
         $expected = <<<HTML
             <div>
@@ -326,7 +326,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->fieldset(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->fieldset(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -340,7 +340,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testFile(): void
     {
-        $html = (new PureFieldFactory())->file()->render();
+        $html = (new FieldFactory())->file()->render();
 
         $expected = <<<HTML
             <div>
@@ -359,7 +359,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->file(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->file(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -372,7 +372,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testHidden(): void
     {
-        $html = (new PureFieldFactory())->hidden()->render();
+        $html = (new FieldFactory())->hidden()->render();
         $this->assertSame('<input type="hidden">', $html);
     }
 
@@ -384,14 +384,14 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->hidden(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->hidden(theme: 'test')->render();
 
         $this->assertSame('<input type="hidden" class="green">', $html);
     }
 
     public function testImage(): void
     {
-        $html = (new PureFieldFactory())->image()->render();
+        $html = (new FieldFactory())->image()->render();
 
         $expected = <<<HTML
             <div>
@@ -404,7 +404,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testImageWithUrl(): void
     {
-        $html = (new PureFieldFactory())->image('image.png')->render();
+        $html = (new FieldFactory())->image('image.png')->render();
 
         $expected = <<<HTML
             <div>
@@ -423,7 +423,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->image(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->image(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -436,7 +436,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testNumber(): void
     {
-        $html = (new PureFieldFactory())->number()->render();
+        $html = (new FieldFactory())->number()->render();
 
         $expected = <<<HTML
             <div>
@@ -455,7 +455,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->number(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->number(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -468,7 +468,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testPassword(): void
     {
-        $html = (new PureFieldFactory())->password()->render();
+        $html = (new FieldFactory())->password()->render();
 
         $expected = <<<HTML
             <div>
@@ -487,7 +487,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->password(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->password(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -500,7 +500,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testRadioList(): void
     {
-        $html = (new PureFieldFactory())->radioList()
+        $html = (new FieldFactory())->radioList()
             ->name('test')
             ->itemsFromValues(['a', 'b'])
             ->render();
@@ -525,7 +525,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->radioList(theme: 'test')
+        $html = (new FieldFactory('default'))->radioList(theme: 'test')
             ->name('test')
             ->itemsFromValues(['a', 'b'])
             ->render();
@@ -544,7 +544,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testRange(): void
     {
-        $html = (new PureFieldFactory())->range()->render();
+        $html = (new FieldFactory())->range()->render();
 
         $expected = <<<HTML
             <div>
@@ -563,7 +563,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->range(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->range(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -576,7 +576,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testResetButton(): void
     {
-        $html = (new PureFieldFactory())->resetButton()->render();
+        $html = (new FieldFactory())->resetButton()->render();
 
         $expected = <<<HTML
             <div>
@@ -589,7 +589,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testResetButtonWithContent(): void
     {
-        $html = (new PureFieldFactory())->resetButton('Reset')->render();
+        $html = (new FieldFactory())->resetButton('Reset')->render();
 
         $expected = <<<HTML
             <div>
@@ -608,7 +608,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->resetButton(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->resetButton(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -621,7 +621,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testSelect(): void
     {
-        $html = (new PureFieldFactory())->select()->render();
+        $html = (new FieldFactory())->select()->render();
 
         $expected = <<<HTML
             <div>
@@ -640,7 +640,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->select(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->select(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -653,7 +653,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testSubmitButton(): void
     {
-        $html = (new PureFieldFactory())->submitButton()->render();
+        $html = (new FieldFactory())->submitButton()->render();
 
         $expected = <<<HTML
             <div>
@@ -666,7 +666,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testSubmitButtonWithContent(): void
     {
-        $html = (new PureFieldFactory())->submitButton('Go')->render();
+        $html = (new FieldFactory())->submitButton('Go')->render();
 
         $expected = <<<HTML
             <div>
@@ -685,7 +685,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->submitButton(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->submitButton(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -698,7 +698,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testTelephone(): void
     {
-        $html = (new PureFieldFactory())->telephone()->render();
+        $html = (new FieldFactory())->telephone()->render();
 
         $expected = <<<HTML
             <div>
@@ -717,7 +717,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->telephone(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->telephone(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -730,7 +730,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testText(): void
     {
-        $html = (new PureFieldFactory())->text()->render();
+        $html = (new FieldFactory())->text()->render();
 
         $expected = <<<HTML
             <div>
@@ -749,7 +749,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->text(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->text(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -762,7 +762,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testTextarea(): void
     {
-        $html = (new PureFieldFactory())->textarea()->render();
+        $html = (new FieldFactory())->textarea()->render();
 
         $expected = <<<HTML
             <div>
@@ -781,7 +781,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->textarea(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->textarea(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -794,7 +794,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testTime(): void
     {
-        $html = (new PureFieldFactory())->time()->render();
+        $html = (new FieldFactory())->time()->render();
 
         $expected = <<<HTML
             <div>
@@ -813,7 +813,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->time(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->time(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -826,7 +826,7 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testUrl(): void
     {
-        $html = (new PureFieldFactory())->url()->render();
+        $html = (new FieldFactory())->url()->render();
 
         $expected = <<<HTML
             <div>
@@ -845,7 +845,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->url(theme: 'test')->render();
+        $html = (new FieldFactory('default'))->url(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -858,13 +858,13 @@ final class PureFieldFactoryTest extends TestCase
 
     public function testLabel(): void
     {
-        $html = (new PureFieldFactory())->label()->render();
+        $html = (new FieldFactory())->label()->render();
         $this->assertSame('', $html);
     }
 
     public function testLabelWithContent(): void
     {
-        $html = (new PureFieldFactory())->label('test')->render();
+        $html = (new FieldFactory())->label('test')->render();
         $this->assertSame('<label>test</label>', $html);
     }
 
@@ -876,20 +876,20 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->label('hello', theme: 'test')->render();
+        $html = (new FieldFactory('default'))->label('hello', theme: 'test')->render();
 
         $this->assertSame('<label class="red">hello</label>', $html);
     }
 
     public function testHint(): void
     {
-        $html = (new PureFieldFactory())->hint()->render();
+        $html = (new FieldFactory())->hint()->render();
         $this->assertSame('', $html);
     }
 
     public function testHintWithContent(): void
     {
-        $html = (new PureFieldFactory())->hint('test')->render();
+        $html = (new FieldFactory())->hint('test')->render();
         $this->assertSame('<div>test</div>', $html);
     }
 
@@ -901,20 +901,20 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->hint('hello', theme: 'test')->render();
+        $html = (new FieldFactory('default'))->hint('hello', theme: 'test')->render();
 
         $this->assertSame('<div class="red">hello</div>', $html);
     }
 
     public function testError(): void
     {
-        $html = (new PureFieldFactory())->error()->render();
+        $html = (new FieldFactory())->error()->render();
         $this->assertSame('', $html);
     }
 
     public function testErrorWithMessage(): void
     {
-        $html = (new PureFieldFactory())->error('test')->render();
+        $html = (new FieldFactory())->error('test')->render();
         $this->assertSame('<div>test</div>', $html);
     }
 
@@ -926,7 +926,7 @@ final class PureFieldFactoryTest extends TestCase
             ],
         ]);
 
-        $html = (new PureFieldFactory('default'))->error('hello', theme: 'test')->render();
+        $html = (new FieldFactory('default'))->error('hello', theme: 'test')->render();
 
         $this->assertSame('<div class="red">hello</div>', $html);
     }

--- a/tests/PureField/FieldTest.php
+++ b/tests/PureField/FieldTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form\Tests;
+namespace Yiisoft\Form\Tests\PureField;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\PureField;
-use Yiisoft\Form\Tests\Support\ThemedPureField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\Field;
+use Yiisoft\Form\Tests\Support\ThemedField;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\Button;
 
-final class PureFieldTest extends TestCase
+final class FieldTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -20,7 +20,7 @@ final class PureFieldTest extends TestCase
 
     public function testButton(): void
     {
-        $html = PureField::button()->render();
+        $html = Field::button()->render();
 
         $expected = <<<HTML
             <div>
@@ -33,7 +33,7 @@ final class PureFieldTest extends TestCase
 
     public function testButtonWithContent(): void
     {
-        $html = PureField::button('Start')->render();
+        $html = Field::button('Start')->render();
 
         $expected = <<<HTML
             <div>
@@ -52,7 +52,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::button(theme: 'test')->render();
+        $html = ThemedField::button(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -65,7 +65,7 @@ final class PureFieldTest extends TestCase
 
     public function testButtonGroup(): void
     {
-        $html = PureField::buttonGroup()->buttons(Button::tag())->render();
+        $html = Field::buttonGroup()->buttons(Button::tag())->render();
 
         $expected = <<<HTML
             <div>
@@ -84,7 +84,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::buttonGroup(theme: 'test')->buttons(Button::tag())->render();
+        $html = ThemedField::buttonGroup(theme: 'test')->buttons(Button::tag())->render();
 
         $expected = <<<HTML
             <span>
@@ -97,7 +97,7 @@ final class PureFieldTest extends TestCase
 
     public function testCheckbox(): void
     {
-        $html = PureField::checkbox()->render();
+        $html = Field::checkbox()->render();
 
         $expected = <<<HTML
             <div>
@@ -116,7 +116,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::checkbox(theme: 'test')->render();
+        $html = ThemedField::checkbox(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -129,7 +129,7 @@ final class PureFieldTest extends TestCase
 
     public function testCheckboxList(): void
     {
-        $html = PureField::checkboxList()
+        $html = Field::checkboxList()
             ->name('test')
             ->itemsFromValues(['a', 'b'])
             ->render();
@@ -154,7 +154,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::checkboxList(theme: 'test')
+        $html = ThemedField::checkboxList(theme: 'test')
             ->name('test')
             ->itemsFromValues(['a', 'b'])
             ->render();
@@ -173,7 +173,7 @@ final class PureFieldTest extends TestCase
 
     public function testDate(): void
     {
-        $html = PureField::date()->render();
+        $html = Field::date()->render();
 
         $expected = <<<HTML
             <div>
@@ -192,7 +192,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::date(theme: 'test')->render();
+        $html = ThemedField::date(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -205,7 +205,7 @@ final class PureFieldTest extends TestCase
 
     public function testDateTimeLocal(): void
     {
-        $html = PureField::dateTimeLocal()->render();
+        $html = Field::dateTimeLocal()->render();
 
         $expected = <<<HTML
             <div>
@@ -224,7 +224,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::dateTimeLocal(theme: 'test')->render();
+        $html = ThemedField::dateTimeLocal(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -237,7 +237,7 @@ final class PureFieldTest extends TestCase
 
     public function testEmail(): void
     {
-        $html = PureField::email()->render();
+        $html = Field::email()->render();
 
         $expected = <<<HTML
             <div>
@@ -256,7 +256,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::email(theme: 'test')->render();
+        $html = ThemedField::email(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -269,7 +269,7 @@ final class PureFieldTest extends TestCase
 
     public function testErrorSummary(): void
     {
-        $html = PureField::errorSummary(['key' => ['e1', 'e2']])->render();
+        $html = Field::errorSummary(['key' => ['e1', 'e2']])->render();
 
         $expected = <<<HTML
             <div>
@@ -291,7 +291,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::errorSummary(['key' => ['e1', 'e2']], theme: 'test')->render();
+        $html = ThemedField::errorSummary(['key' => ['e1', 'e2']], theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -307,7 +307,7 @@ final class PureFieldTest extends TestCase
 
     public function testFieldset(): void
     {
-        $html = PureField::fieldset()->render();
+        $html = Field::fieldset()->render();
 
         $expected = <<<HTML
             <div>
@@ -327,7 +327,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::fieldset(theme: 'test')->render();
+        $html = ThemedField::fieldset(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -341,7 +341,7 @@ final class PureFieldTest extends TestCase
 
     public function testFile(): void
     {
-        $html = PureField::file()->render();
+        $html = Field::file()->render();
 
         $expected = <<<HTML
             <div>
@@ -360,7 +360,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::file(theme: 'test')->render();
+        $html = ThemedField::file(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -373,7 +373,7 @@ final class PureFieldTest extends TestCase
 
     public function testHidden(): void
     {
-        $html = PureField::hidden()->render();
+        $html = Field::hidden()->render();
         $this->assertSame('<input type="hidden">', $html);
     }
 
@@ -385,14 +385,14 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::hidden(theme: 'test')->render();
+        $html = ThemedField::hidden(theme: 'test')->render();
 
         $this->assertSame('<input type="hidden" class="green">', $html);
     }
 
     public function testImage(): void
     {
-        $html = PureField::image()->render();
+        $html = Field::image()->render();
 
         $expected = <<<HTML
             <div>
@@ -405,7 +405,7 @@ final class PureFieldTest extends TestCase
 
     public function testImageWithUrl(): void
     {
-        $html = PureField::image('image.png')->render();
+        $html = Field::image('image.png')->render();
 
         $expected = <<<HTML
             <div>
@@ -424,7 +424,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::image(theme: 'test')->render();
+        $html = ThemedField::image(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -437,7 +437,7 @@ final class PureFieldTest extends TestCase
 
     public function testNumber(): void
     {
-        $html = PureField::number()->render();
+        $html = Field::number()->render();
 
         $expected = <<<HTML
             <div>
@@ -456,7 +456,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::number(theme: 'test')->render();
+        $html = ThemedField::number(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -469,7 +469,7 @@ final class PureFieldTest extends TestCase
 
     public function testPassword(): void
     {
-        $html = PureField::password()->render();
+        $html = Field::password()->render();
 
         $expected = <<<HTML
             <div>
@@ -488,7 +488,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::password(theme: 'test')->render();
+        $html = ThemedField::password(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -501,7 +501,7 @@ final class PureFieldTest extends TestCase
 
     public function testRadioList(): void
     {
-        $html = PureField::radioList()
+        $html = Field::radioList()
             ->name('test')
             ->itemsFromValues(['a', 'b'])
             ->render();
@@ -526,7 +526,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::radioList(theme: 'test')
+        $html = ThemedField::radioList(theme: 'test')
             ->name('test')
             ->itemsFromValues(['a', 'b'])
             ->render();
@@ -545,7 +545,7 @@ final class PureFieldTest extends TestCase
 
     public function testRange(): void
     {
-        $html = PureField::range()->render();
+        $html = Field::range()->render();
 
         $expected = <<<HTML
             <div>
@@ -564,7 +564,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::range(theme: 'test')->render();
+        $html = ThemedField::range(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -577,7 +577,7 @@ final class PureFieldTest extends TestCase
 
     public function testResetButton(): void
     {
-        $html = PureField::resetButton()->render();
+        $html = Field::resetButton()->render();
 
         $expected = <<<HTML
             <div>
@@ -590,7 +590,7 @@ final class PureFieldTest extends TestCase
 
     public function testResetButtonWithContent(): void
     {
-        $html = PureField::resetButton('Reset')->render();
+        $html = Field::resetButton('Reset')->render();
 
         $expected = <<<HTML
             <div>
@@ -609,7 +609,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::resetButton(theme: 'test')->render();
+        $html = ThemedField::resetButton(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -622,7 +622,7 @@ final class PureFieldTest extends TestCase
 
     public function testSelect(): void
     {
-        $html = PureField::select()->render();
+        $html = Field::select()->render();
 
         $expected = <<<HTML
             <div>
@@ -641,7 +641,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::select(theme: 'test')->render();
+        $html = ThemedField::select(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -654,7 +654,7 @@ final class PureFieldTest extends TestCase
 
     public function testSubmitButton(): void
     {
-        $html = PureField::submitButton()->render();
+        $html = Field::submitButton()->render();
 
         $expected = <<<HTML
             <div>
@@ -667,7 +667,7 @@ final class PureFieldTest extends TestCase
 
     public function testSubmitButtonWithContent(): void
     {
-        $html = PureField::submitButton('Go')->render();
+        $html = Field::submitButton('Go')->render();
 
         $expected = <<<HTML
             <div>
@@ -686,7 +686,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::submitButton(theme: 'test')->render();
+        $html = ThemedField::submitButton(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -699,7 +699,7 @@ final class PureFieldTest extends TestCase
 
     public function testTelephone(): void
     {
-        $html = PureField::telephone()->render();
+        $html = Field::telephone()->render();
 
         $expected = <<<HTML
             <div>
@@ -718,7 +718,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::telephone(theme: 'test')->render();
+        $html = ThemedField::telephone(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -731,7 +731,7 @@ final class PureFieldTest extends TestCase
 
     public function testText(): void
     {
-        $html = PureField::text()->render();
+        $html = Field::text()->render();
 
         $expected = <<<HTML
             <div>
@@ -750,7 +750,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::text(theme: 'test')->render();
+        $html = ThemedField::text(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -763,7 +763,7 @@ final class PureFieldTest extends TestCase
 
     public function testTextarea(): void
     {
-        $html = PureField::textarea()->render();
+        $html = Field::textarea()->render();
 
         $expected = <<<HTML
             <div>
@@ -782,7 +782,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::textarea(theme: 'test')->render();
+        $html = ThemedField::textarea(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -795,7 +795,7 @@ final class PureFieldTest extends TestCase
 
     public function testTime(): void
     {
-        $html = PureField::time()->render();
+        $html = Field::time()->render();
 
         $expected = <<<HTML
             <div>
@@ -814,7 +814,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::time(theme: 'test')->render();
+        $html = ThemedField::time(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -827,7 +827,7 @@ final class PureFieldTest extends TestCase
 
     public function testUrl(): void
     {
-        $html = PureField::url()->render();
+        $html = Field::url()->render();
 
         $expected = <<<HTML
             <div>
@@ -846,7 +846,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::url(theme: 'test')->render();
+        $html = ThemedField::url(theme: 'test')->render();
 
         $expected = <<<HTML
             <span>
@@ -859,13 +859,13 @@ final class PureFieldTest extends TestCase
 
     public function testLabel(): void
     {
-        $html = PureField::label()->render();
+        $html = Field::label()->render();
         $this->assertSame('', $html);
     }
 
     public function testLabelWithContent(): void
     {
-        $html = PureField::label('test')->render();
+        $html = Field::label('test')->render();
         $this->assertSame('<label>test</label>', $html);
     }
 
@@ -877,20 +877,20 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::label('hello', theme: 'test')->render();
+        $html = ThemedField::label('hello', theme: 'test')->render();
 
         $this->assertSame('<label class="red">hello</label>', $html);
     }
 
     public function testHint(): void
     {
-        $html = PureField::hint()->render();
+        $html = Field::hint()->render();
         $this->assertSame('', $html);
     }
 
     public function testHintWithContent(): void
     {
-        $html = PureField::hint('test')->render();
+        $html = Field::hint('test')->render();
         $this->assertSame('<div>test</div>', $html);
     }
 
@@ -902,20 +902,20 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::hint('hello', theme: 'test')->render();
+        $html = ThemedField::hint('hello', theme: 'test')->render();
 
         $this->assertSame('<div class="red">hello</div>', $html);
     }
 
     public function testError(): void
     {
-        $html = PureField::error()->render();
+        $html = Field::error()->render();
         $this->assertSame('', $html);
     }
 
     public function testErrorWithMessage(): void
     {
-        $html = PureField::error('test')->render();
+        $html = Field::error('test')->render();
         $this->assertSame('<div>test</div>', $html);
     }
 
@@ -927,7 +927,7 @@ final class PureFieldTest extends TestCase
             ],
         ]);
 
-        $html = ThemedPureField::error('hello', theme: 'test')->render();
+        $html = ThemedField::error('hello', theme: 'test')->render();
 
         $this->assertSame('<div class="red">hello</div>', $html);
     }

--- a/tests/Support/ThemedField.php
+++ b/tests/Support/ThemedField.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Yiisoft\Form\Tests\Support;
 
-use Yiisoft\Form\PureField;
+use Yiisoft\Form\PureField\Field;
 
-final class ThemedPureField extends PureField
+final class ThemedField extends Field
 {
     protected const DEFAULT_THEME = 'default';
 }

--- a/tests/Theme/ThemeTest.php
+++ b/tests/Theme/ThemeTest.php
@@ -448,10 +448,10 @@ final class ThemeTest extends TestCase
 
     #[DataProvider('dataText')]
     public function testText(
-        string    $expected,
-        array     $factoryParameters,
+        string $expected,
+        array $factoryParameters,
         InputData $inputData,
-        ?array    $enricherResult = null,
+        ?array $enricherResult = null,
     ): void {
         $this->initializeThemeContainer($factoryParameters, $enricherResult);
 
@@ -518,8 +518,8 @@ final class ThemeTest extends TestCase
 
     #[DataProvider('dataTextWithNotDefaultTheme')]
     public function testTextWithNotDefaultTheme(
-        string    $expected,
-        array     $factoryParameters,
+        string $expected,
+        array $factoryParameters,
         InputData $inputData,
     ): void {
         ThemeContainer::initialize(

--- a/tests/Theme/ThemeTest.php
+++ b/tests/Theme/ThemeTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Form\Tests;
+namespace Yiisoft\Form\Tests\Theme;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
+use Yiisoft\Form\Field\Fieldset;
 use Yiisoft\Form\Field\Part\Error;
 use Yiisoft\Form\Field\Part\Hint;
-use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
-use Yiisoft\Form\Field\Fieldset;
 use Yiisoft\Form\Field\Part\Label;
-use Yiisoft\Form\ThemeContainer;
 use Yiisoft\Form\Field\Text;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Tests\Support\StubValidationRulesEnricher;
+use Yiisoft\Form\Theme\ThemeContainer;
 
 final class ThemeTest extends TestCase
 {
@@ -30,7 +30,7 @@ final class ThemeTest extends TestCase
                 </div>
                 HTML,
                 [],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[name]',
                     value: '',
                     label: 'Name',
@@ -51,7 +51,7 @@ final class ThemeTest extends TestCase
                 [
                     'enrichFromValidationRules' => true,
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[company]',
                     value: '',
                     label: 'Company',
@@ -69,7 +69,7 @@ final class ThemeTest extends TestCase
                 [
                     'enrichFromValidationRules' => false,
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[company]',
                     value: '',
                 ),
@@ -86,7 +86,7 @@ final class ThemeTest extends TestCase
                     'containerTag' => 'section',
                     'containerAttributes' => ['class' => 'wrapper'],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -101,7 +101,7 @@ final class ThemeTest extends TestCase
                 </div>
                 HTML,
                 ['containerClass' => 'wrapper'],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -116,7 +116,7 @@ final class ThemeTest extends TestCase
                 </div>
                 HTML,
                 ['containerClass' => ['wrapper', 'red']],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -131,7 +131,7 @@ final class ThemeTest extends TestCase
                 </div>
                 HTML,
                 ['inputClass' => 'red'],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -146,7 +146,7 @@ final class ThemeTest extends TestCase
                 </div>
                 HTML,
                 ['inputClass' => ['red', 'blue']],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -161,7 +161,7 @@ final class ThemeTest extends TestCase
                 [
                     'useContainer' => false,
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -182,7 +182,7 @@ final class ThemeTest extends TestCase
                 [
                     'template' => "<div class=\"wrap\">\n{hint}\n{label}\n{error}\n{input}\n</div>",
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[name]',
                     value: '',
                     label: 'Name',
@@ -203,7 +203,7 @@ final class ThemeTest extends TestCase
                     'setInputId' => false,
                     'inputAttributes' => ['class' => 'form-control'],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -230,7 +230,7 @@ final class ThemeTest extends TestCase
                         'attributes()' => [['class' => 'red']],
                     ],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[name]',
                     value: '',
                     label: 'Name',
@@ -252,7 +252,7 @@ final class ThemeTest extends TestCase
                 [
                     'usePlaceholder' => false,
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[name]',
                     value: '',
                     label: 'Name',
@@ -274,7 +274,7 @@ final class ThemeTest extends TestCase
                 [
                     'usePlaceholder' => false,
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[name]',
                     value: '',
                     label: 'Name',
@@ -304,7 +304,7 @@ final class ThemeTest extends TestCase
                         ],
                     ],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -322,7 +322,7 @@ final class ThemeTest extends TestCase
                     'validClass' => 'valid',
                     'containerAttributes' => ['class' => 'wrapper'],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -342,7 +342,7 @@ final class ThemeTest extends TestCase
                     'invalidClass' => 'invalid',
                     'containerAttributes' => ['class' => 'wrapper'],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[company]',
                     value: '',
                     label: 'Company',
@@ -361,7 +361,7 @@ final class ThemeTest extends TestCase
                     'inputValidClass' => 'valid',
                     'containerAttributes' => ['class' => 'wrapper'],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -381,7 +381,7 @@ final class ThemeTest extends TestCase
                     'inputInvalidClass' => 'invalid',
                     'containerAttributes' => ['class' => 'wrapper'],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[company]',
                     value: '',
                     label: 'Company',
@@ -400,7 +400,7 @@ final class ThemeTest extends TestCase
                     'inputContainerTag' => 'div',
                     'inputContainerAttributes' => ['class' => 'control'],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -418,7 +418,7 @@ final class ThemeTest extends TestCase
                     'inputContainerTag' => 'div',
                     'inputContainerClass' => 'control',
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -436,7 +436,7 @@ final class ThemeTest extends TestCase
                     'inputContainerTag' => 'div',
                     'inputContainerClass' => ['control', 'red'],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'TextForm[job]',
                     value: '',
                     label: 'Job',
@@ -448,10 +448,10 @@ final class ThemeTest extends TestCase
 
     #[DataProvider('dataText')]
     public function testText(
-        string $expected,
-        array $factoryParameters,
-        PureInputData $inputData,
-        ?array $enricherResult = null,
+        string    $expected,
+        array     $factoryParameters,
+        InputData $inputData,
+        ?array    $enricherResult = null,
     ): void {
         $this->initializeThemeContainer($factoryParameters, $enricherResult);
 
@@ -475,7 +475,7 @@ final class ThemeTest extends TestCase
                 [
                     'labelConfig' => ['class()' => ['red']],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'job',
                     value: '',
                     label: 'Job',
@@ -491,7 +491,7 @@ final class ThemeTest extends TestCase
                 [
                     'hintConfig' => ['class()' => ['red']],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'job',
                     value: '',
                     hint: 'Job',
@@ -507,7 +507,7 @@ final class ThemeTest extends TestCase
                 [
                     'errorConfig' => ['class()' => ['red']],
                 ],
-                new PureInputData(
+                new InputData(
                     name: 'job',
                     value: '',
                     validationErrors: ['Error'],
@@ -518,9 +518,9 @@ final class ThemeTest extends TestCase
 
     #[DataProvider('dataTextWithNotDefaultTheme')]
     public function testTextWithNotDefaultTheme(
-        string $expected,
-        array $factoryParameters,
-        PureInputData $inputData,
+        string    $expected,
+        array     $factoryParameters,
+        InputData $inputData,
     ): void {
         ThemeContainer::initialize(
             ['default' => [], 'custom-theme' => $factoryParameters],
@@ -543,7 +543,7 @@ final class ThemeTest extends TestCase
             ],
         ]);
 
-        $inputData = new PureInputData(
+        $inputData = new InputData(
             id: 'textform-job',
             label: 'Job',
             name: 'TextForm[job]',
@@ -662,7 +662,7 @@ final class ThemeTest extends TestCase
         $this->initializeThemeContainer($factoryParameters);
 
         $result = Label::widget()
-            ->inputData(new PureInputData(id: 'textform-job', label: 'Job'))
+            ->inputData(new InputData(id: 'textform-job', label: 'Job'))
             ->render();
 
         $this->assertSame($expected, $result);

--- a/themes-preview/bootstrap5/bootstrap5-horizontal.php
+++ b/themes-preview/bootstrap5/bootstrap5-horizontal.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Yiisoft\Form\ThemePath;
+use Yiisoft\Form\Theme\ThemePath;
 
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 

--- a/themes-preview/bootstrap5/bootstrap5-vertical.php
+++ b/themes-preview/bootstrap5/bootstrap5-vertical.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Yiisoft\Form\ThemePath;
+use Yiisoft\Form\Theme\ThemePath;
 
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 

--- a/themes-preview/template.php
+++ b/themes-preview/template.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Yiisoft\Form\Field\Base\InputData\PureInputData;
 use Yiisoft\Form\Field\Text;
-use Yiisoft\Form\PureField;
-use Yiisoft\Form\ThemeContainer;
+use Yiisoft\Form\PureField\Field;
+use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
 /**
@@ -32,70 +32,70 @@ echo '<!DOCTYPE html>';
 <body>
 <div style="max-width: 1000px;padding: 24px;margin: 0 auto">
     <?php
-    echo PureField::text()->label('Text Field')->placeholder('Placeholder')->hint('Example of hint');
+    echo Field::text()->label('Text Field')->placeholder('Placeholder')->hint('Example of hint');
 
     echo Text::widget()
-        ->inputData(new PureInputData(validationErrors: []))
+        ->inputData(new InputData(validationErrors: []))
         ->label('Valid Text Field')
         ->placeholder('Placeholder');
 
-    echo PureField::text()->label('Invalid Text Field')->placeholder('Placeholder')->error('Example of error');
+    echo Field::text()->label('Invalid Text Field')->placeholder('Placeholder')->error('Example of error');
 
-    echo PureField::textarea()->label('Textarea Field')->placeholder('Placeholder');
+    echo Field::textarea()->label('Textarea Field')->placeholder('Placeholder');
 
-    echo PureField::password()->label('Password Field')->placeholder('Placeholder');
+    echo Field::password()->label('Password Field')->placeholder('Placeholder');
 
-    echo PureField::url()->label('Url Field')->placeholder('Placeholder');
+    echo Field::url()->label('Url Field')->placeholder('Placeholder');
 
-    echo PureField::email()->label('Email Field')->placeholder('Placeholder');
+    echo Field::email()->label('Email Field')->placeholder('Placeholder');
 
-    echo PureField::time()->label('Time Field');
+    echo Field::time()->label('Time Field');
 
-    echo PureField::date()->label('Date Field');
+    echo Field::date()->label('Date Field');
 
-    echo PureField::dateTime()->label('DateTime Field');
+    echo Field::dateTime()->label('DateTime Field');
 
-    echo PureField::dateTimeLocal()->label('DateTimeLocal Field');
+    echo Field::dateTimeLocal()->label('DateTimeLocal Field');
 
-    echo PureField::telephone()->label('Telephone Field')->placeholder('Placeholder');
+    echo Field::telephone()->label('Telephone Field')->placeholder('Placeholder');
 
-    echo PureField::number()->label('Number Field')->placeholder('Placeholder');
+    echo Field::number()->label('Number Field')->placeholder('Placeholder');
 
-    echo PureField::range()->label('Range Field');
+    echo Field::range()->label('Range Field');
 
-    echo PureField::select()
+    echo Field::select()
         ->label('Select Field')
         ->optionsData(['Red', 'Green', 'Blue']);
 
-    echo PureField::checkbox()->label('Checkbox Field');
+    echo Field::checkbox()->label('Checkbox Field');
 
-    echo PureField::checkboxList('checkbox-list')
+    echo Field::checkboxList('checkbox-list')
         ->label('Checkbox List Field')
         ->itemsFromValues(['One', 'Two', 'Three']);
 
-    echo PureField::radioList('radio-list')
+    echo Field::radioList('radio-list')
         ->label('Radio List Field')
         ->itemsFromValues(['One', 'Two', 'Three']);
 
-    echo PureField::file()->label('File Field');
+    echo Field::file()->label('File Field');
 
-    echo PureField::image('image-field.png');
+    echo Field::image('image-field.png');
 
-    echo PureField::button('Button');
+    echo Field::button('Button');
 
-    echo PureField::submitButton('Submit Button');
+    echo Field::submitButton('Submit Button');
 
-    echo PureField::resetButton('Reset Button');
+    echo Field::resetButton('Reset Button');
 
-    echo PureField::buttonGroup()->buttonsData([['This'], ['is'], ['button'], ['group']]);
+    echo Field::buttonGroup()->buttonsData([['This'], ['is'], ['button'], ['group']]);
 
-    $fieldset = PureField::fieldset()->legend('Fieldset');
+    $fieldset = Field::fieldset()->legend('Fieldset');
     echo $fieldset->begin();
-    echo PureField::text()->label('First Name');
-    echo PureField::text()->label('Last Name');
+    echo Field::text()->label('First Name');
+    echo Field::text()->label('Last Name');
     echo $fieldset::end();
 
-    echo PureField::errorSummary(
+    echo Field::errorSummary(
         [
             'name' => ['Value not passed.'],
             'number' => ['Value must be no greater than 7.'],
@@ -103,11 +103,11 @@ echo '<!DOCTYPE html>';
         ]
     )->header('Error Summary');
 
-    echo PureField::label('Label Example');
+    echo Field::label('Label Example');
 
-    echo PureField::hint('Hint Example');
+    echo Field::hint('Hint Example');
 
-    echo PureField::error('Error Example')->addAttributes(['style' => 'display: block;']);
+    echo Field::error('Error Example')->addAttributes(['style' => 'display: block;']);
     ?>
 </div>
 </body>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

- Move theme related classes to a separate namespace.
- Remove "pure" prefix from field, factory and input data class names.
- Move field factory related classes and input data to a separate namespace.


