### PR TITLE
Add `before*`/`after*` input methods to `Checkbox`, `CheckboxList` and `RadioList` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New #388: Add `beforeCheckbox()` and `afterCheckbox()` methods to `Checkbox` and `CheckboxList` fields (@vjik)
 - New #388: Add `beforeRadio()` and `afterRadio()` methods to `RadioList` field (@vjik)
+- Enh #386: Bump minimal `yiisoft/html` version to `^4.2` (@vjik)
 
 ## 1.5.2 March 20, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.5.3 under development
 
-- no changes in this release.
+- New #388: Add `beforeCheckbox()` and `afterCheckbox()` methods to `Checkbox` and `CheckboxList` fields (@vjik)
+- New #388: Add `beforeRadio()` and `afterRadio()` methods to `RadioList` field (@vjik)
 
 ## 1.5.2 March 20, 2026
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "8.1 - 8.5",
         "yiisoft/friendly-exception": "^1.0",
-        "yiisoft/html": "^3.13 || ^4.0",
+        "yiisoft/html": "dev-master as 4.2",
         "yiisoft/widget": "^2.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "8.1 - 8.5",
         "yiisoft/friendly-exception": "^1.0",
-        "yiisoft/html": "dev-master as 4.2",
+        "yiisoft/html": "^4.2",
         "yiisoft/widget": "^2.2"
     },
     "require-dev": {

--- a/src/Field/Checkbox.php
+++ b/src/Field/Checkbox.php
@@ -31,6 +31,8 @@ final class Checkbox extends InputField implements ValidationClassInterface
     private array $inputLabelAttributes = [];
     private bool $inputLabelEncode = true;
     private ?string $inputValue = null;
+    private string|Stringable $beforeCheckbox = '';
+    private string|Stringable $afterCheckbox = '';
 
     /**
      * Identifies the element (or elements) that describes the object.
@@ -220,6 +222,26 @@ final class Checkbox extends InputField implements ValidationClassInterface
         return $new;
     }
 
+    /**
+     * @param string|Stringable $content Content to be rendered before the checkbox input.
+     */
+    public function beforeCheckbox(string|Stringable $content): self
+    {
+        $new = clone $this;
+        $new->beforeCheckbox = $content;
+        return $new;
+    }
+
+    /**
+     * @param string|Stringable $content Content to be rendered after the checkbox input.
+     */
+    public function afterCheckbox(string|Stringable $content): self
+    {
+        $new = clone $this;
+        $new->afterCheckbox = $content;
+        return $new;
+    }
+
     protected function generateInput(): string
     {
         $value = $this->getValue();
@@ -261,6 +283,8 @@ final class Checkbox extends InputField implements ValidationClassInterface
         }
 
         $html = $checkbox
+            ->beforeInput($this->beforeCheckbox)
+            ->afterInput($this->afterCheckbox)
             ->checked($inputValue === $value)
             ->uncheckValue($this->uncheckValue)
             ->render();

--- a/src/Field/CheckboxList.php
+++ b/src/Field/CheckboxList.php
@@ -183,6 +183,26 @@ final class CheckboxList extends PartsField implements ValidationClassInterface
     }
 
     /**
+     * @param string|Stringable $content Content to be rendered before each checkbox input.
+     */
+    public function beforeCheckbox(string|Stringable $content): self
+    {
+        $new = clone $this;
+        $new->widget = $this->widget->beforeCheckbox($content);
+        return $new;
+    }
+
+    /**
+     * @param string|Stringable $content Content to be rendered after each checkbox input.
+     */
+    public function afterCheckbox(string|Stringable $content): self
+    {
+        $new = clone $this;
+        $new->widget = $this->widget->afterCheckbox($content);
+        return $new;
+    }
+
+    /**
      * @psalm-param Closure(CheckboxItem):string|null $formatter
      */
     public function itemFormatter(?Closure $formatter): self

--- a/src/Field/RadioList.php
+++ b/src/Field/RadioList.php
@@ -184,6 +184,26 @@ final class RadioList extends PartsField implements ValidationClassInterface
     }
 
     /**
+     * @param string|Stringable $content Content to be rendered before each radio input.
+     */
+    public function beforeRadio(string|Stringable $content): self
+    {
+        $new = clone $this;
+        $new->widget = $this->widget->beforeRadio($content);
+        return $new;
+    }
+
+    /**
+     * @param string|Stringable $content Content to be rendered after each radio input.
+     */
+    public function afterRadio(string|Stringable $content): self
+    {
+        $new = clone $this;
+        $new->widget = $this->widget->afterRadio($content);
+        return $new;
+    }
+
+    /**
      * @psalm-param Closure(RadioItem):string|null $formatter
      */
     public function itemFormatter(?Closure $formatter): self

--- a/tests/Field/CheckboxListTest.php
+++ b/tests/Field/CheckboxListTest.php
@@ -8,8 +8,10 @@ use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Stringable;
 use Yiisoft\Form\Field\CheckboxList;
 use Yiisoft\Form\PureField\InputData;
+use Yiisoft\Form\Tests\Support\StringableObject;
 use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Widget\CheckboxList\CheckboxItem;
@@ -550,6 +552,64 @@ final class CheckboxListTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public static function dataBeforeCheckbox(): array
+    {
+        return [
+            'string' => ['<b>*</b>', '<b>*</b>'],
+            'stringable' => ['<b>*</b>', new StringableObject('<b>*</b>')],
+        ];
+    }
+
+    #[DataProvider('dataBeforeCheckbox')]
+    public function testBeforeCheckbox(string $expectedContent, string|Stringable $content): void
+    {
+        $result = CheckboxList::widget()
+            ->name('color')
+            ->items(['red' => 'Red', 'blue' => 'Blue'])
+            ->beforeCheckbox($content)
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <div>
+            <label>$expectedContent<input name="color[]" value="red" type="checkbox"> Red</label>
+            <label>$expectedContent<input name="color[]" value="blue" type="checkbox"> Blue</label>
+            </div>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public static function dataAfterCheckbox(): array
+    {
+        return [
+            'string' => ['<b>*</b>', '<b>*</b>'],
+            'stringable' => ['<b>*</b>', new StringableObject('<b>*</b>')],
+        ];
+    }
+
+    #[DataProvider('dataAfterCheckbox')]
+    public function testAfterCheckbox(string $expectedContent, string|Stringable $content): void
+    {
+        $result = CheckboxList::widget()
+            ->name('color')
+            ->items(['red' => 'Red', 'blue' => 'Blue'])
+            ->afterCheckbox($content)
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <div>
+            <label><input name="color[]" value="red" type="checkbox">$expectedContent Red</label>
+            <label><input name="color[]" value="blue" type="checkbox">$expectedContent Blue</label>
+            </div>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testImmutability(): void
     {
         $field = CheckboxList::widget();
@@ -572,5 +632,7 @@ final class CheckboxListTest extends TestCase
         $this->assertNotSame($field, $field->uncheckValue(null));
         $this->assertNotSame($field, $field->separator(''));
         $this->assertNotSame($field, $field->itemFormatter(null));
+        $this->assertNotSame($field, $field->beforeCheckbox(''));
+        $this->assertNotSame($field, $field->afterCheckbox(''));
     }
 }

--- a/tests/Field/CheckboxTest.php
+++ b/tests/Field/CheckboxTest.php
@@ -126,6 +126,24 @@ final class CheckboxTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @see https://github.com/yiisoft/form/issues/387
+     */
+    public function testIssue387(): void
+    {
+        $result = Checkbox::widget()
+            ->useContainer(false)
+            ->inputData(new InputData(value: true, label: 'Label text'))
+            ->inputLabelClass('switch')
+            ->afterCheckbox('<span class="track"></span>')
+            ->render();
+
+        $this->assertSame(
+            '<label class="switch"><input value="1" checked type="checkbox"><span class="track"></span> Label text</label>',
+            $result,
+        );
+    }
+
     public static function dataUncheckValue(): array
     {
         return [

--- a/tests/Field/CheckboxTest.php
+++ b/tests/Field/CheckboxTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Stringable;
 use Yiisoft\Form\Field\Checkbox;
 use Yiisoft\Form\Field\CheckboxLabelPlacement;
 use Yiisoft\Form\PureField\InputData;
@@ -838,6 +839,56 @@ final class CheckboxTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public static function dataBeforeCheckbox(): array
+    {
+        return [
+            'string' => ['<b>*</b>', '<b>*</b>'],
+            'stringable' => ['<b>*</b>', new StringableObject('<b>*</b>')],
+        ];
+    }
+
+    #[DataProvider('dataBeforeCheckbox')]
+    public function testBeforeCheckbox(string $expectedContent, string|Stringable $content): void
+    {
+        $result = Checkbox::widget()
+            ->beforeCheckbox($content)
+            ->label('Blue color')
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <label>$expectedContent<input value="1" type="checkbox"> Blue color</label>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public static function dataAfterCheckbox(): array
+    {
+        return [
+            'string' => ['<b>*</b>', '<b>*</b>'],
+            'stringable' => ['<b>*</b>', new StringableObject('<b>*</b>')],
+        ];
+    }
+
+    #[DataProvider('dataAfterCheckbox')]
+    public function testAfterCheckbox(string $expectedContent, string|Stringable $content): void
+    {
+        $result = Checkbox::widget()
+            ->afterCheckbox($content)
+            ->label('Blue color')
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <label><input value="1" type="checkbox">$expectedContent Blue color</label>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testImmutability(): void
     {
         $widget = Checkbox::widget();
@@ -858,5 +909,7 @@ final class CheckboxTest extends TestCase
         $this->assertNotSame($widget, $widget->autofocus());
         $this->assertNotSame($widget, $widget->tabIndex(null));
         $this->assertNotSame($widget, $widget->inputLabelEncode(true));
+        $this->assertNotSame($widget, $widget->beforeCheckbox(''));
+        $this->assertNotSame($widget, $widget->afterCheckbox(''));
     }
 }

--- a/tests/Field/RadioListTest.php
+++ b/tests/Field/RadioListTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Stringable;
 use Yiisoft\Form\Field\RadioList;
 use Yiisoft\Form\PureField\InputData;
 use Yiisoft\Form\Tests\Support\StringableObject;
@@ -764,6 +765,64 @@ final class RadioListTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public static function dataBeforeRadio(): array
+    {
+        return [
+            'string' => ['<b>*</b>', '<b>*</b>'],
+            'stringable' => ['<b>*</b>', new StringableObject('<b>*</b>')],
+        ];
+    }
+
+    #[DataProvider('dataBeforeRadio')]
+    public function testBeforeRadio(string $expectedContent, string|Stringable $content): void
+    {
+        $result = RadioList::widget()
+            ->name('color')
+            ->items(['red' => 'Red', 'blue' => 'Blue'])
+            ->beforeRadio($content)
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <div>
+            <label>$expectedContent<input name="color" value="red" type="radio"> Red</label>
+            <label>$expectedContent<input name="color" value="blue" type="radio"> Blue</label>
+            </div>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public static function dataAfterRadio(): array
+    {
+        return [
+            'string' => ['<b>*</b>', '<b>*</b>'],
+            'stringable' => ['<b>*</b>', new StringableObject('<b>*</b>')],
+        ];
+    }
+
+    #[DataProvider('dataAfterRadio')]
+    public function testAfterRadio(string $expectedContent, string|Stringable $content): void
+    {
+        $result = RadioList::widget()
+            ->name('color')
+            ->items(['red' => 'Red', 'blue' => 'Blue'])
+            ->afterRadio($content)
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <div>
+            <label><input name="color" value="red" type="radio">$expectedContent Red</label>
+            <label><input name="color" value="blue" type="radio">$expectedContent Blue</label>
+            </div>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testImmutability(): void
     {
         $field = RadioList::widget();
@@ -786,5 +845,7 @@ final class RadioListTest extends TestCase
         $this->assertNotSame($field, $field->uncheckValue(null));
         $this->assertNotSame($field, $field->separator(''));
         $this->assertNotSame($field, $field->itemFormatter(null));
+        $this->assertNotSame($field, $field->beforeRadio(''));
+        $this->assertNotSame($field, $field->afterRadio(''));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
Fix #387 