### PR TITLE
Fix #376: Allow `ButtonField` instances in `ButtonGroup::buttons()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.3 under development
 
+- New #376: Allow `ButtonField` instances in `ButtonGroup::buttons()` (@Mister-42)
 - New #388: Add `beforeCheckbox()` and `afterCheckbox()` methods to `Checkbox` and `CheckboxList` fields (@vjik)
 - New #388: Add `beforeRadio()` and `afterRadio()` methods to `RadioList` field (@vjik)
 - Enh #386: Bump minimal `yiisoft/html` version to `^4.2` (@vjik)

--- a/src/Field/Base/ButtonField.php
+++ b/src/Field/Base/ButtonField.php
@@ -170,7 +170,7 @@ abstract class ButtonField extends PartsField
         return $new;
     }
 
-    final protected function generateInput(): string
+    final public function getButtonTag(): Button
     {
         $button = ($this->button ?? new Button())
             ->type($this->getType());
@@ -184,7 +184,12 @@ abstract class ButtonField extends PartsField
             $button = $button->content($content);
         }
 
-        return $button->render();
+        return $button;
+    }
+
+    final protected function generateInput(): string
+    {
+        return $this->getButtonTag()->render();
     }
 
     abstract protected function getType(): string;

--- a/src/Field/Base/ButtonField.php
+++ b/src/Field/Base/ButtonField.php
@@ -170,7 +170,7 @@ abstract class ButtonField extends PartsField
         return $new;
     }
 
-    final public function getButtonTag(): Button
+    final public function getButton(): Button
     {
         $button = ($this->button ?? new Button())
             ->type($this->getType());
@@ -189,7 +189,7 @@ abstract class ButtonField extends PartsField
 
     final protected function generateInput(): string
     {
-        return $this->getButtonTag()->render();
+        return $this->getButton()->render();
     }
 
     abstract protected function getType(): string;

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Form\Field;
 
+use Yiisoft\Form\Field\Base\ButtonField;
 use Yiisoft\Form\Field\Base\PartsField;
 use Yiisoft\Html\Tag\Button as ButtonTag;
 use Yiisoft\Html\Widget\ButtonGroup as ButtonGroupWidget;
@@ -22,10 +23,16 @@ final class ButtonGroup extends PartsField
         $this->widget = (new ButtonGroupWidget())->withoutContainer();
     }
 
-    public function buttons(ButtonTag ...$buttons): self
+    public function buttons(ButtonTag|ButtonField ...$buttons): self
     {
         $new = clone $this;
-        $new->widget = $this->widget->buttons(...$buttons);
+        $htmlButtons = [];
+        foreach ($buttons as $button) {
+            $htmlButtons[] = $button instanceof ButtonField
+                ? $button->getButtonTag()
+                : $button;
+        }
+        $new->widget = $this->widget->buttons(...$htmlButtons);
         return $new;
     }
 

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -26,13 +26,13 @@ final class ButtonGroup extends PartsField
     public function buttons(ButtonTag|ButtonField ...$buttons): self
     {
         $new = clone $this;
-        $htmlButtons = [];
+        $buttonTags = [];
         foreach ($buttons as $button) {
-            $htmlButtons[] = $button instanceof ButtonField
-                ? $button->getButtonTag()
+            $buttonTags[] = $button instanceof ButtonField
+                ? $button->getButton()
                 : $button;
         }
-        $new->widget = $this->widget->buttons(...$htmlButtons);
+        $new->widget = $this->widget->buttons(...$buttonTags);
         return $new;
     }
 

--- a/tests/Field/Base/ButtonFieldTest.php
+++ b/tests/Field/Base/ButtonFieldTest.php
@@ -18,22 +18,16 @@ final class ButtonFieldTest extends TestCase
         ThemeContainer::initialize();
     }
 
-    public function testGetButtonTag(): void
+    public function testGetButton(): void
     {
         $field = StubButtonField::widget()
             ->content('Click Me')
             ->addButtonClass('btn');
 
-        $tag = $field->getButtonTag();
+        $tag = $field->getButton();
 
         $expected = '<button type="button" class="btn">Click Me</button>';
         $this->assertSame($expected, $tag->render());
-    }
-
-    public function testGetButtonTagImmutability(): void
-    {
-        $field = StubButtonField::widget();
-        $this->assertNotSame($field, $field->getButtonTag());
     }
 
     public function testBase(): void
@@ -396,5 +390,6 @@ final class ButtonFieldTest extends TestCase
         $this->assertNotSame($field, $field->tabIndex(null));
         $this->assertNotSame($field, $field->disabled());
         $this->assertNotSame($field, $field->form(null));
+        $this->assertNotSame($field, $field->getButton());
     }
 }

--- a/tests/Field/Base/ButtonFieldTest.php
+++ b/tests/Field/Base/ButtonFieldTest.php
@@ -18,6 +18,24 @@ final class ButtonFieldTest extends TestCase
         ThemeContainer::initialize();
     }
 
+    public function testGetButtonTag(): void
+    {
+        $field = StubButtonField::widget()
+            ->content('Click Me')
+            ->addButtonClass('btn');
+
+        $tag = $field->getButtonTag();
+
+        $expected = '<button type="button" class="btn">Click Me</button>';
+        $this->assertSame($expected, $tag->render());
+    }
+
+    public function testGetButtonTagImmutability(): void
+    {
+        $field = StubButtonField::widget();
+        $this->assertNotSame($field, $field->getButtonTag());
+    }
+
     public function testBase(): void
     {
         $result = StubButtonField::widget()

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -231,6 +231,46 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testButtonsWithFieldButtonWithTheme(): void
+    {
+        ThemeContainer::initialize(
+            [
+                'default' => [
+                    'fieldConfigs' => [
+                        ButtonGroup::class => [
+                            'containerClass()' => ['btn-toolbar justify-content-end'],
+                        ],
+                        ResetButton::class => [
+                            'buttonClass()' => ['btn', 'btn-secondary'],
+                            'content()' => ['Reset'],
+                        ],
+                        SubmitButton::class => [
+                            'buttonClass()' => ['btn', 'btn-primary'],
+                            'content()' => ['Submit'],
+                        ],
+                    ],
+                ],
+            ],
+            'default',
+        );
+
+        $result = ButtonGroup::widget()
+            ->buttons(
+                ResetButton::widget(),
+                SubmitButton::widget(),
+            )
+            ->render();
+
+        $expected = <<<HTML
+            <div class="btn-toolbar justify-content-end">
+            <button type="reset" class="btn btn-secondary">Reset</button>
+            <button type="submit" class="btn btn-primary">Submit</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testButtonsWithFieldButtonCustomized(): void
     {
         $result = ButtonGroup::widget()

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Yiisoft\Form\Tests\Field;
 
 use PHPUnit\Framework\TestCase;
+use Yiisoft\Form\Field\Button;
 use Yiisoft\Form\Field\ButtonGroup;
+use Yiisoft\Form\Field\ResetButton;
+use Yiisoft\Form\Field\SubmitButton;
 use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
@@ -152,6 +155,96 @@ final class ButtonGroupTest extends TestCase
             <button type="reset">Reset</button>
             <br>
             <button type="submit">Send</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsWithFieldButton(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttons(
+                Button::widget()->content('Click'),
+            )
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="button">Click</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsWithResetButton(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttons(
+                ResetButton::widget()->content('Reset'),
+            )
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="reset">Reset</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsWithSubmitButton(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttons(
+                SubmitButton::widget()->content('Send'),
+            )
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="submit">Send</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsWithMixedFieldButtonsAndHtmlTags(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttons(
+                Html::resetButton('Reset Data'),
+                SubmitButton::widget()->content('Send'),
+            )
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="reset">Reset Data</button>
+            <button type="submit">Send</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsWithFieldButtonCustomized(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttons(
+                SubmitButton::widget()
+                    ->content('Go!')
+                    ->addButtonClass('btn-primary')
+                    ->disabled(),
+            )
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="submit" class="btn-primary" disabled>Go!</button>
             </div>
             HTML;
 

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -9,6 +9,7 @@ use Yiisoft\Form\Field\Button;
 use Yiisoft\Form\Field\ButtonGroup;
 use Yiisoft\Form\Field\ResetButton;
 use Yiisoft\Form\Field\SubmitButton;
+use Yiisoft\Form\Tests\Support\ThemedField as Field;
 use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Html;
 
@@ -240,6 +241,9 @@ final class ButtonGroupTest extends TestCase
                         ButtonGroup::class => [
                             'containerClass()' => ['btn-toolbar justify-content-end'],
                         ],
+                        Button::class => [
+                            'content()' => ['Click'],
+                        ],
                         ResetButton::class => [
                             'buttonClass()' => ['btn', 'btn-secondary'],
                             'content()' => ['Reset'],
@@ -254,15 +258,17 @@ final class ButtonGroupTest extends TestCase
             'default',
         );
 
-        $result = ButtonGroup::widget()
+        $result = Field::ButtonGroup()
             ->buttons(
-                ResetButton::widget(),
-                SubmitButton::widget(),
+                Field::button(),
+                Field::resetButton(),
+                Field::submitButton(),
             )
             ->render();
 
         $expected = <<<HTML
             <div class="btn-toolbar justify-content-end">
+            <button type="button">Click</button>
             <button type="reset" class="btn btn-secondary">Reset</button>
             <button type="submit" class="btn btn-primary">Submit</button>
             </div>


### PR DESCRIPTION
## Description

Currently `ButtonGroup::buttons()` only accepts `Yiisoft\Html\Tag\Button` (raw HTML tags), making it impossible to use `Field::button()`, `Field::resetButton()`, or `Field::submitButton()` directly.

This PR adds a `ButtonField::getButtonTag()` method that exposes the raw HTML button tag from a button field, and widens `ButtonGroup::buttons()` to accept both `ButtonTag` and `ButtonField` instances, converting the latter internally.

Fixes #376

## Changes

- **`src/Field/Base/ButtonField.php`** — Added `final public function getButtonTag(): Button` that returns the configured `Yiisoft\Html\Tag\Button` without rendering the full field template. Refactored `generateInput()` to use it.
- **`src/Field/ButtonGroup.php`** — Widened `buttons(ButtonTag ...$buttons)` to `buttons(ButtonTag|ButtonField ...$buttons)`. `ButtonField` instances are converted to `ButtonTag` via `getButtonTag()`.
- **`CHANGELOG.md`** — Added entry for #376.

## Testing

- Added 2 tests in `ButtonFieldTest` for `getButtonTag()`
- Added 5 tests in `ButtonGroupTest` for passing `Button`, `ResetButton`, `SubmitButton` field instances (solo, mixed with HTML tags, customized with class/disabled)

All 1083 tests pass, zero CS issues.