### PR TITLE
Fix #399: Add `$themed` parameter to `ButtonGroup::buttonsData()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - New #388: Add `beforeRadio()` and `afterRadio()` methods to `RadioList` field (@vjik)
 - Enh #386: Bump minimal `yiisoft/html` version to `^4.2` (@vjik)
 - Enh #392: Move `.meta-storm.xml` to the project root (@Mister-42)
-- Enh #399: Add `$asWidget` parameter to `ButtonGroup::buttonsData()` method (@Mister-42)
+- Enh #399: Add `$themed` parameter to `ButtonGroup::buttonsData()` method (@Mister-42)
 
 ## 1.5.2 March 20, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New #388: Add `beforeRadio()` and `afterRadio()` methods to `RadioList` field (@vjik)
 - Enh #386: Bump minimal `yiisoft/html` version to `^4.2` (@vjik)
 - Enh #392: Move `.meta-storm.xml` to the project root (@Mister-42)
+- Enh #399: Add `ButtonGroup::buttonsFieldData()` method (@va108)
 
 ## 1.5.2 March 20, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - New #388: Add `beforeRadio()` and `afterRadio()` methods to `RadioList` field (@vjik)
 - Enh #386: Bump minimal `yiisoft/html` version to `^4.2` (@vjik)
 - Enh #392: Move `.meta-storm.xml` to the project root (@Mister-42)
-- Enh #399: Add `$themed` parameter to `ButtonGroup::buttonsData()` method (@Mister-42)
+- New #399: Add `$themed` parameter to `ButtonGroup::buttonsData()` method (@Mister-42)
 
 ## 1.5.2 March 20, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - New #388: Add `beforeRadio()` and `afterRadio()` methods to `RadioList` field (@vjik)
 - Enh #386: Bump minimal `yiisoft/html` version to `^4.2` (@vjik)
 - Enh #392: Move `.meta-storm.xml` to the project root (@Mister-42)
-- Enh #399: Add `ButtonGroup::buttonsFieldData()` method (@va108)
+- Enh #399: Add `ButtonGroup::buttonsFieldData()` method (@Mister-42)
 
 ## 1.5.2 March 20, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - New #388: Add `beforeRadio()` and `afterRadio()` methods to `RadioList` field (@vjik)
 - Enh #386: Bump minimal `yiisoft/html` version to `^4.2` (@vjik)
 - Enh #392: Move `.meta-storm.xml` to the project root (@Mister-42)
-- Enh #399: Add `ButtonGroup::buttonsFieldData()` method (@Mister-42)
+- Enh #399: Add `$asWidget` parameter to `ButtonGroup::buttonsData()` method (@Mister-42)
 
 ## 1.5.2 March 20, 2026
 

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Form\Field;
 
+use InvalidArgumentException;
 use Yiisoft\Form\Field\Base\ButtonField;
 use Yiisoft\Form\Field\Base\PartsField;
 use Yiisoft\Form\Theme\ThemeContainer;
@@ -75,29 +76,34 @@ final class ButtonGroup extends PartsField
 
         $buttonTags = [];
         foreach ($data as $item) {
-            if (is_array($item)) {
-                $label = $item[0] ?? null;
-                $attributes = array_slice($item, 1, null, true);
-
-                $type = strtolower((string) ($attributes['type'] ?? 'button'));
-                unset($attributes['type']);
-
-                $buttonWidget = match ($type) {
-                    'reset' => ResetButton::widget(),
-                    'submit' => SubmitButton::widget(),
-                    default => Button::widget(),
-                };
-
-                if ($label !== null) {
-                    $buttonWidget = $buttonWidget->content((string) $label);
-                }
-
-                $buttonTags[] = $buttonWidget
-                    ->encodeContent(false)
-                    ->addButtonAttributes($attributes)
-                    ->getButton()
-                    ->encode($encode);
+            if (!is_array($item)) {
+                throw new InvalidArgumentException(
+                    'Invalid buttons data. A data row must be array with label as first element '
+                    . 'and additional name-value pairs as attributes of button.',
+                );
             }
+
+            $label = $item[0] ?? null;
+            $attributes = array_slice($item, 1, null, true);
+
+            $type = strtolower((string) ($attributes['type'] ?? 'button'));
+            unset($attributes['type']);
+
+            $buttonWidget = match ($type) {
+                'reset' => ResetButton::widget(),
+                'submit' => SubmitButton::widget(),
+                default => Button::widget(),
+            };
+
+            if ($label !== null) {
+                $buttonWidget = $buttonWidget->content((string) $label);
+            }
+
+            $buttonTags[] = $buttonWidget
+                ->encodeContent(false)
+                ->addButtonAttributes($attributes)
+                ->getButton()
+                ->encode($encode);
         }
 
         $new->widget = $this->widget->buttons(...$buttonTags);

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -67,7 +67,7 @@ final class ButtonGroup extends PartsField
      * - `submit` → {@see SubmitButton}
      * - default → {@see Button}
      *
-     * @param array $data Array of buttons. Each button is an array with label as first element and additional
+     * @param list<array> $data Array of buttons. Each button is an array with label as first element and additional
      * name-value pairs as attributes of button.
      *
      * Example:
@@ -83,7 +83,7 @@ final class ButtonGroup extends PartsField
     {
         $buttons = [];
         foreach ($data as $item) {
-            $label = $item[0] ?? '';
+            $label = (string) ($item[0] ?? '');
             $attributes = array_slice($item, 1, null, true);
 
             $type = $attributes['type'] ?? 'button';

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -103,13 +103,7 @@ final class ButtonGroup extends PartsField
                 ->encodeContent(false)
                 ->addButtonAttributes($attributes);
 
-            $buttonTag = $buttonField->getButton();
-
-            if (!$encode) {
-                $buttonTag = $buttonTag->encode(false);
-            }
-
-            $buttons[] = $buttonTag;
+            $buttons[] = $buttonField->getButton()->encode($encode);
         }
 
         return $this->buttons(...$buttons);

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -64,34 +64,39 @@ final class ButtonGroup extends PartsField
      */
     public function buttonsData(array $data, bool $encode = true, bool $themed = false): self
     {
-        $factory = $themed
-            ? static function (array $item, bool $encode): ButtonTag {
-                $label = $item[0] ?? null;
-                $attributes = array_slice($item, 1, null, true);
-
-                $type = $attributes['type'] ?? 'button';
-                unset($attributes['type']);
-
-                $buttonWidget = match ($type) {
-                    'reset' => ResetButton::widget(),
-                    'submit' => SubmitButton::widget(),
-                    default => Button::widget(),
-                };
-
-                if ($label !== null) {
-                    $buttonWidget = $buttonWidget->content((string) $label);
-                }
-
-                return $buttonWidget
-                    ->encodeContent(false)
-                    ->addButtonAttributes($attributes)
-                    ->getButton()
-                    ->encode($encode);
-            }
-            : null;
-
         $new = clone $this;
-        $new->widget = $this->widget->buttonsData($data, $encode, $factory);
+
+        if (!$themed) {
+            $new->widget = $this->widget->buttonsData($data, $encode);
+            return $new;
+        }
+
+        $buttonTags = [];
+        foreach ($data as $item) {
+            $label = $item[0] ?? null;
+            $attributes = array_slice($item, 1, null, true);
+
+            $type = $attributes['type'] ?? 'button';
+            unset($attributes['type']);
+
+            $buttonWidget = match ($type) {
+                'reset' => ResetButton::widget(),
+                'submit' => SubmitButton::widget(),
+                default => Button::widget(),
+            };
+
+            if ($label !== null) {
+                $buttonWidget = $buttonWidget->content((string) $label);
+            }
+
+            $buttonTags[] = $buttonWidget
+                ->encodeContent(false)
+                ->addButtonAttributes($attributes)
+                ->getButton()
+                ->encode($encode);
+        }
+
+        $new->widget = $this->widget->buttons(...$buttonTags);
         return $new;
     }
 

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -72,17 +72,17 @@ final class ButtonGroup extends PartsField
                 $type = $attributes['type'] ?? 'button';
                 unset($attributes['type']);
 
-                $buttonField = match ($type) {
+                $buttonWidget = match ($type) {
                     'reset' => ResetButton::widget(),
                     'submit' => SubmitButton::widget(),
                     default => Button::widget(),
                 };
 
                 if ($label !== null) {
-                    $buttonField = $buttonField->content((string) $label);
+                    $buttonWidget = $buttonWidget->content((string) $label);
                 }
 
-                return $buttonField
+                return $buttonWidget
                     ->encodeContent(false)
                     ->addButtonAttributes($attributes)
                     ->getButton()

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Form\Field;
 
 use Yiisoft\Form\Field\Base\ButtonField;
 use Yiisoft\Form\Field\Base\PartsField;
+use Yiisoft\Form\Theme\ThemeContainer;
 use Yiisoft\Html\Tag\Button as ButtonTag;
 use Yiisoft\Html\Widget\ButtonGroup as ButtonGroupWidget;
 
@@ -50,63 +51,48 @@ final class ButtonGroup extends PartsField
      * ]
      * ```
      * @param bool $encode Whether button content should be HTML-encoded.
+     * @param bool $themed When true, creates buttons via {@see ButtonField} instances
+     * ({@see Button}, {@see ResetButton}, {@see SubmitButton}) instead of raw tag buttons.
+     * The `type` attribute determines which subclass is used:
+     * `reset` → {@see ResetButton}, `submit` → {@see SubmitButton}, default → {@see Button}.
+     * If label is null, the content from the theme is used.
+     * Theme styling only applies when the host application has configured a theme via
+     * {@see ThemeContainer}. Without a configured theme, the output is identical to the
+     * default (non-themed) behavior.
+     *
+     * In a future major version, the default value of this parameter will change to `true`.
      */
-    public function buttonsData(array $data, bool $encode = true): self
+    public function buttonsData(array $data, bool $encode = true, bool $themed = false): self
     {
-        $new = clone $this;
-        $new->widget = $this->widget->buttonsData($data, $encode);
-        return $new;
-    }
+        $factory = $themed
+            ? static function (array $item, bool $encode): ButtonTag {
+                $label = $item[0] ?? null;
+                $attributes = array_slice($item, 1, null, true);
 
-    /**
-     * Creates buttons from array data using {@see ButtonField} instances instead of raw tag buttons.
-     *
-     * Each button is an array with label as first element and additional name-value pairs as attributes.
-     * The `type` attribute determines which ButtonField subclass is used:
-     * - `reset` → {@see ResetButton}
-     * - `submit` → {@see SubmitButton}
-     * - default → {@see Button}
-     *
-     * @param list<array> $data Array of buttons. Each button is an array with label as first element and additional
-     * name-value pairs as attributes of button. If label is null, the content from the theme is used.
-     *
-     * Example:
-     * ```php
-     * [
-     *     ['Reset', 'type' => 'reset', 'class' => 'default'],
-     *     ['Send', 'type' => 'submit', 'class' => 'primary'],
-     * ]
-     * ```
-     * @param bool $encode Whether button content should be HTML-encoded.
-     */
-    public function buttonsFieldData(array $data, bool $encode = true): self
-    {
-        $buttons = [];
-        foreach ($data as $item) {
-            $label = $item[0] ?? null;
-            $attributes = array_slice($item, 1, null, true);
+                $type = $attributes['type'] ?? 'button';
+                unset($attributes['type']);
 
-            $type = $attributes['type'] ?? 'button';
-            unset($attributes['type']);
+                $buttonField = match ($type) {
+                    'reset' => ResetButton::widget(),
+                    'submit' => SubmitButton::widget(),
+                    default => Button::widget(),
+                };
 
-            $buttonField = match ($type) {
-                'reset' => ResetButton::widget(),
-                'submit' => SubmitButton::widget(),
-                default => Button::widget(),
-            };
+                if ($label !== null) {
+                    $buttonField = $buttonField->content((string) $label);
+                }
 
-            if ($label !== null) {
-                $buttonField = $buttonField->content((string) $label);
+                return $buttonField
+                    ->encodeContent(false)
+                    ->addButtonAttributes($attributes)
+                    ->getButton()
+                    ->encode($encode);
             }
+            : null;
 
-            $buttonField = $buttonField
-                ->encodeContent(false)
-                ->addButtonAttributes($attributes);
-
-            $buttons[] = $buttonField->getButton()->encode($encode);
-        }
-
-        return $this->buttons(...$buttons);
+        $new = clone $this;
+        $new->widget = $this->widget->buttonsData($data, $encode, $factory);
+        return $new;
     }
 
     public function buttonAttributes(array $attributes): self

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -11,6 +11,7 @@ use Yiisoft\Html\Tag\Button as ButtonTag;
 use Yiisoft\Html\Widget\ButtonGroup as ButtonGroupWidget;
 
 use function array_slice;
+use function is_array;
 
 /**
  * Represents a button group widget.

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -8,8 +8,8 @@ use Yiisoft\Form\Field\Base\ButtonField;
 use Yiisoft\Form\Field\Base\PartsField;
 use Yiisoft\Html\Tag\Button as ButtonTag;
 use Yiisoft\Html\Widget\ButtonGroup as ButtonGroupWidget;
-use Yiisoft\Form\Field\ResetButton;
-use Yiisoft\Form\Field\SubmitButton;
+
+use function array_slice;
 
 /**
  * Represents a button group widget.

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -68,7 +68,7 @@ final class ButtonGroup extends PartsField
      * - default → {@see Button}
      *
      * @param list<array> $data Array of buttons. Each button is an array with label as first element and additional
-     * name-value pairs as attributes of button.
+     * name-value pairs as attributes of button. If label is null, the content from the theme is used.
      *
      * Example:
      * ```php
@@ -83,7 +83,7 @@ final class ButtonGroup extends PartsField
     {
         $buttons = [];
         foreach ($data as $item) {
-            $label = (string) ($item[0] ?? '');
+            $label = $item[0] ?? null;
             $attributes = array_slice($item, 1, null, true);
 
             $type = $attributes['type'] ?? 'button';
@@ -95,8 +95,11 @@ final class ButtonGroup extends PartsField
                 default => Button::widget(),
             };
 
+            if ($label !== null) {
+                $buttonField = $buttonField->content((string) $label);
+            }
+
             $buttonField = $buttonField
-                ->content($label)
                 ->encodeContent(false)
                 ->addButtonAttributes($attributes);
 

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -77,7 +77,7 @@ final class ButtonGroup extends PartsField
                 $label = $item[0] ?? null;
                 $attributes = array_slice($item, 1, null, true);
 
-                $type = $attributes['type'] ?? 'button';
+                $type = strtolower((string) ($attributes['type'] ?? 'button'));
                 unset($attributes['type']);
 
                 $buttonWidget = match ($type) {

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -73,30 +73,29 @@ final class ButtonGroup extends PartsField
 
         $buttonTags = [];
         foreach ($data as $item) {
-            if (!is_array($item)) {
-                continue;
+            if (is_array($item)) {
+                $label = $item[0] ?? null;
+                $attributes = array_slice($item, 1, null, true);
+
+                $type = $attributes['type'] ?? 'button';
+                unset($attributes['type']);
+
+                $buttonWidget = match ($type) {
+                    'reset' => ResetButton::widget(),
+                    'submit' => SubmitButton::widget(),
+                    default => Button::widget(),
+                };
+
+                if ($label !== null) {
+                    $buttonWidget = $buttonWidget->content((string) $label);
+                }
+
+                $buttonTags[] = $buttonWidget
+                    ->encodeContent(false)
+                    ->addButtonAttributes($attributes)
+                    ->getButton()
+                    ->encode($encode);
             }
-            $label = $item[0] ?? null;
-            $attributes = array_slice($item, 1, null, true);
-
-            $type = $attributes['type'] ?? 'button';
-            unset($attributes['type']);
-
-            $buttonWidget = match ($type) {
-                'reset' => ResetButton::widget(),
-                'submit' => SubmitButton::widget(),
-                default => Button::widget(),
-            };
-
-            if ($label !== null) {
-                $buttonWidget = $buttonWidget->content((string) $label);
-            }
-
-            $buttonTags[] = $buttonWidget
-                ->encodeContent(false)
-                ->addButtonAttributes($attributes)
-                ->getButton()
-                ->encode($encode);
         }
 
         $new->widget = $this->widget->buttons(...$buttonTags);

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -12,6 +12,7 @@ use Yiisoft\Html\Widget\ButtonGroup as ButtonGroupWidget;
 
 use function array_slice;
 use function is_array;
+use function strtolower;
 
 /**
  * Represents a button group widget.

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -73,6 +73,9 @@ final class ButtonGroup extends PartsField
 
         $buttonTags = [];
         foreach ($data as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
             $label = $item[0] ?? null;
             $attributes = array_slice($item, 1, null, true);
 

--- a/src/Field/ButtonGroup.php
+++ b/src/Field/ButtonGroup.php
@@ -8,6 +8,8 @@ use Yiisoft\Form\Field\Base\ButtonField;
 use Yiisoft\Form\Field\Base\PartsField;
 use Yiisoft\Html\Tag\Button as ButtonTag;
 use Yiisoft\Html\Widget\ButtonGroup as ButtonGroupWidget;
+use Yiisoft\Form\Field\ResetButton;
+use Yiisoft\Form\Field\SubmitButton;
 
 /**
  * Represents a button group widget.
@@ -54,6 +56,60 @@ final class ButtonGroup extends PartsField
         $new = clone $this;
         $new->widget = $this->widget->buttonsData($data, $encode);
         return $new;
+    }
+
+    /**
+     * Creates buttons from array data using {@see ButtonField} instances instead of raw tag buttons.
+     *
+     * Each button is an array with label as first element and additional name-value pairs as attributes.
+     * The `type` attribute determines which ButtonField subclass is used:
+     * - `reset` → {@see ResetButton}
+     * - `submit` → {@see SubmitButton}
+     * - default → {@see Button}
+     *
+     * @param array $data Array of buttons. Each button is an array with label as first element and additional
+     * name-value pairs as attributes of button.
+     *
+     * Example:
+     * ```php
+     * [
+     *     ['Reset', 'type' => 'reset', 'class' => 'default'],
+     *     ['Send', 'type' => 'submit', 'class' => 'primary'],
+     * ]
+     * ```
+     * @param bool $encode Whether button content should be HTML-encoded.
+     */
+    public function buttonsFieldData(array $data, bool $encode = true): self
+    {
+        $buttons = [];
+        foreach ($data as $item) {
+            $label = $item[0] ?? '';
+            $attributes = array_slice($item, 1, null, true);
+
+            $type = $attributes['type'] ?? 'button';
+            unset($attributes['type']);
+
+            $buttonField = match ($type) {
+                'reset' => ResetButton::widget(),
+                'submit' => SubmitButton::widget(),
+                default => Button::widget(),
+            };
+
+            $buttonField = $buttonField
+                ->content($label)
+                ->encodeContent(false)
+                ->addButtonAttributes($attributes);
+
+            $buttonTag = $buttonField->getButton();
+
+            if (!$encode) {
+                $buttonTag = $buttonTag->encode(false);
+            }
+
+            $buttons[] = $buttonTag;
+        }
+
+        return $this->buttons(...$buttons);
     }
 
     public function buttonAttributes(array $attributes): self

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Form\Tests\Field;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Form\Field\Button;
 use Yiisoft\Form\Field\ButtonGroup;
@@ -504,22 +505,19 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testButtonsDataThemedSkipsNonArrayItems(): void
+    public function testButtonsDataThemedThrowsExceptionForNonArrayItem(): void
     {
-        $result = ButtonGroup::widget()
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Invalid buttons data. A data row must be array with label as first element '
+            . 'and additional name-value pairs as attributes of button.',
+        );
+        ButtonGroup::widget()
             ->buttonsData([
                 'invalid',
                 ['Send', 'type' => 'submit'],
             ], themed: true)
             ->render();
-
-        $expected = <<<HTML
-            <div>
-            <button type="submit">Send</button>
-            </div>
-            HTML;
-
-        $this->assertSame($expected, $result);
     }
 
     public function testImmutability(): void

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -297,13 +297,13 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testButtonsFieldData(): void
+    public function testButtonsDataThemed(): void
     {
         $result = ButtonGroup::widget()
-            ->buttonsFieldData([
+            ->buttonsData([
                 ['Reset', 'type' => 'reset', 'class' => 'default'],
                 ['Send >', 'type' => 'submit', 'class' => 'primary'],
-            ])
+            ], themed: true)
             ->render();
 
         $expected = <<<HTML
@@ -316,12 +316,12 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testButtonsFieldDataDefaultType(): void
+    public function testButtonsDataThemedDefaultType(): void
     {
         $result = ButtonGroup::widget()
-            ->buttonsFieldData([
+            ->buttonsData([
                 ['Click', 'class' => 'btn'],
-            ])
+            ], themed: true)
             ->render();
 
         $expected = <<<HTML
@@ -333,12 +333,12 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testButtonsFieldDataNoEncode(): void
+    public function testButtonsDataThemedNoEncode(): void
     {
         $result = ButtonGroup::widget()
-            ->buttonsFieldData([
+            ->buttonsData([
                 ['<b>Bold</b>', 'type' => 'submit'],
-            ], false)
+            ], false, themed: true)
             ->render();
 
         $expected = <<<HTML
@@ -350,10 +350,10 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testButtonsFieldDataEmpty(): void
+    public function testButtonsDataThemedEmpty(): void
     {
         $result = ButtonGroup::widget()
-            ->buttonsFieldData([])
+            ->buttonsData([], themed: true)
             ->render();
 
         $expected = <<<HTML
@@ -364,12 +364,12 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testButtonsFieldDataIntegerLabel(): void
+    public function testButtonsDataThemedIntegerLabel(): void
     {
         $result = ButtonGroup::widget()
-            ->buttonsFieldData([
+            ->buttonsData([
                 [0, 'type' => 'submit'],
-            ])
+            ], themed: true)
             ->render();
 
         $expected = <<<HTML
@@ -381,7 +381,7 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testButtonsFieldDataWithTheme(): void
+    public function testButtonsDataThemedWithTheme(): void
     {
         ThemeContainer::initialize(
             [
@@ -405,10 +405,10 @@ final class ButtonGroupTest extends TestCase
         );
 
         $result = Field::ButtonGroup()
-            ->buttonsFieldData([
+            ->buttonsData([
                 [null, 'type' => 'reset'],
                 ['Send', 'type' => 'submit'],
-            ])
+            ], themed: true)
             ->render();
 
         $expected = <<<HTML
@@ -427,7 +427,7 @@ final class ButtonGroupTest extends TestCase
 
         $this->assertNotSame($field, $field->buttons());
         $this->assertNotSame($field, $field->buttonsData([]));
-        $this->assertNotSame($field, $field->buttonsFieldData([]));
+        $this->assertNotSame($field, $field->buttonsData([], themed: true));
         $this->assertNotSame($field, $field->buttonAttributes([]));
         $this->assertNotSame($field, $field->addButtonAttributes([]));
         $this->assertNotSame($field, $field->disabled());

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -297,12 +297,121 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testButtonsFieldData(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttonsFieldData([
+                ['Reset', 'type' => 'reset', 'class' => 'default'],
+                ['Send >', 'type' => 'submit', 'class' => 'primary'],
+            ])
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="reset" class="default">Reset</button>
+            <button type="submit" class="primary">Send &gt;</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsFieldDataDefaultType(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttonsFieldData([
+                ['Click', 'class' => 'btn'],
+            ])
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="button" class="btn">Click</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsFieldDataNoEncode(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttonsFieldData([
+                ['<b>Bold</b>', 'type' => 'submit'],
+            ], false)
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="submit"><b>Bold</b></button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsFieldDataEmpty(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttonsFieldData([])
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsFieldDataWithTheme(): void
+    {
+        ThemeContainer::initialize(
+            [
+                'default' => [
+                    'fieldConfigs' => [
+                        ButtonGroup::class => [
+                            'containerClass()' => ['btn-toolbar justify-content-end'],
+                        ],
+                        Button::class => [
+                            'buttonClass()' => ['btn', 'btn-default'],
+                        ],
+                        ResetButton::class => [
+                            'buttonClass()' => ['btn', 'btn-secondary'],
+                        ],
+                        SubmitButton::class => [
+                            'buttonClass()' => ['btn', 'btn-primary'],
+                        ],
+                    ],
+                ],
+            ],
+            'default',
+        );
+
+        $result = Field::ButtonGroup()
+            ->buttonsFieldData([
+                ['Reset', 'type' => 'reset'],
+                ['Send', 'type' => 'submit'],
+            ])
+            ->render();
+
+        $expected = <<<HTML
+            <div class="btn-toolbar justify-content-end">
+            <button type="reset" class="btn btn-secondary">Reset</button>
+            <button type="submit" class="btn btn-primary">Send</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testImmutability(): void
     {
         $field = ButtonGroup::widget();
 
         $this->assertNotSame($field, $field->buttons());
         $this->assertNotSame($field, $field->buttonsData([]));
+        $this->assertNotSame($field, $field->buttonsFieldData([]));
         $this->assertNotSame($field, $field->buttonAttributes([]));
         $this->assertNotSame($field, $field->addButtonAttributes([]));
         $this->assertNotSame($field, $field->disabled());

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -421,6 +421,64 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testButtonsDataDefaultNotThemedWithTheme(): void
+    {
+        ThemeContainer::initialize(
+            [
+                'default' => [
+                    'fieldConfigs' => [
+                        ButtonGroup::class => [
+                            'containerClass()' => ['btn-toolbar justify-content-end'],
+                        ],
+                        ResetButton::class => [
+                            'buttonClass()' => ['btn', 'btn-secondary'],
+                            'content()' => ['Reset'],
+                        ],
+                        SubmitButton::class => [
+                            'buttonClass()' => ['btn', 'btn-primary'],
+                            'content()' => ['Submit'],
+                        ],
+                    ],
+                ],
+            ],
+            'default',
+        );
+
+        $result = ButtonGroup::widget()
+            ->buttonsData([
+                ['Reset', 'type' => 'reset'],
+                ['Send', 'type' => 'submit'],
+            ])
+            ->render();
+
+        $expected = <<<HTML
+            <div class="btn-toolbar justify-content-end">
+            <button type="reset">Reset</button>
+            <button type="submit">Send</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsDataThemedSkipsNonArrayItems(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttonsData([
+                'invalid',
+                ['Send', 'type' => 'submit'],
+            ], themed: true)
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="submit">Send</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testImmutability(): void
     {
         $field = ButtonGroup::widget();

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -426,6 +426,9 @@ final class ButtonGroupTest extends TestCase
                         ButtonGroup::class => [
                             'containerClass()' => ['btn-toolbar justify-content-end'],
                         ],
+                        Button::class => [
+                            'content()' => ['Click'],
+                        ],
                         ResetButton::class => [
                             'buttonClass()' => ['btn', 'btn-secondary'],
                             'content()' => ['Reset'],
@@ -442,6 +445,8 @@ final class ButtonGroupTest extends TestCase
 
         $result = Field::ButtonGroup()
             ->buttonsData([
+				[],
+				['type' => 'button'],
                 [null, 'type' => 'reset'],
                 ['Send', 'type' => 'submit'],
             ], themed: true)
@@ -449,6 +454,8 @@ final class ButtonGroupTest extends TestCase
 
         $expected = <<<HTML
             <div class="btn-toolbar justify-content-end">
+            <button type="button">Click</button>
+            <button type="button">Click</button>
             <button type="reset" class="btn btn-secondary">Reset</button>
             <button type="submit" class="btn btn-primary">Send</button>
             </div>

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -445,8 +445,8 @@ final class ButtonGroupTest extends TestCase
 
         $result = Field::ButtonGroup()
             ->buttonsData([
-				[],
-				['type' => 'button'],
+                [],
+                ['type' => 'button'],
                 [null, 'type' => 'reset'],
                 ['Send', 'type' => 'submit'],
             ], themed: true)

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -407,14 +407,14 @@ final class ButtonGroupTest extends TestCase
         $result = Field::ButtonGroup()
             ->buttonsFieldData([
                 [null, 'type' => 'reset'],
-                [null, 'type' => 'submit'],
+                ['Send', 'type' => 'submit'],
             ])
             ->render();
 
         $expected = <<<HTML
             <div class="btn-toolbar justify-content-end">
             <button type="reset" class="btn btn-secondary">Reset</button>
-            <button type="submit" class="btn btn-primary">Submit</button>
+            <button type="submit" class="btn btn-primary">Send</button>
             </div>
             HTML;
 

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -390,14 +390,13 @@ final class ButtonGroupTest extends TestCase
                         ButtonGroup::class => [
                             'containerClass()' => ['btn-toolbar justify-content-end'],
                         ],
-                        Button::class => [
-                            'buttonClass()' => ['btn', 'btn-default'],
-                        ],
                         ResetButton::class => [
                             'buttonClass()' => ['btn', 'btn-secondary'],
+                            'content()' => ['Reset'],
                         ],
                         SubmitButton::class => [
                             'buttonClass()' => ['btn', 'btn-primary'],
+                            'content()' => ['Submit'],
                         ],
                     ],
                 ],
@@ -407,15 +406,15 @@ final class ButtonGroupTest extends TestCase
 
         $result = Field::ButtonGroup()
             ->buttonsFieldData([
-                ['Reset', 'type' => 'reset'],
-                ['Send', 'type' => 'submit'],
+                [null, 'type' => 'reset'],
+                [null, 'type' => 'submit'],
             ])
             ->render();
 
         $expected = <<<HTML
             <div class="btn-toolbar justify-content-end">
             <button type="reset" class="btn btn-secondary">Reset</button>
-            <button type="submit" class="btn btn-primary">Send</button>
+            <button type="submit" class="btn btn-primary">Submit</button>
             </div>
             HTML;
 

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -333,6 +333,42 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testButtonsDataThemedCaseInsensitiveType(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttonsData([
+                ['Reset', 'type' => 'RESET'],
+                ['Send', 'type' => 'Submit'],
+            ], themed: true)
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="reset">Reset</button>
+            <button type="submit">Send</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testButtonsDataThemedIntegerType(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttonsData([
+                ['Click', 'type' => 123],
+            ], themed: true)
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="button">Click</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testButtonsDataThemedNoEncode(): void
     {
         $result = ButtonGroup::widget()

--- a/tests/Field/ButtonGroupTest.php
+++ b/tests/Field/ButtonGroupTest.php
@@ -364,6 +364,23 @@ final class ButtonGroupTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testButtonsFieldDataIntegerLabel(): void
+    {
+        $result = ButtonGroup::widget()
+            ->buttonsFieldData([
+                [0, 'type' => 'submit'],
+            ])
+            ->render();
+
+        $expected = <<<HTML
+            <div>
+            <button type="submit">0</button>
+            </div>
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testButtonsFieldDataWithTheme(): void
     {
         ThemeContainer::initialize(


### PR DESCRIPTION
Adds a `bool $themed` parameter to `ButtonGroup::buttonsData()`.

When `themed: true`, buttons are created via `ButtonField` instances (`Button`, `ResetButton`, `SubmitButton`) instead of raw `Tag\Button` objects. This enables theme support for buttons created from array data. Theme styling only applies when the host application has configured a theme via `ThemeContainer`.

Depends on yiisoft/html#285.

| Q | A |
|---|---|
| Is bugfix? | ❌ |
| New feature? | ✔️ |
| Breaks BC? | ❌ |
| Fixed issues  | <!-- none -->